### PR TITLE
Disable html linter and test linting

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,3 +31,4 @@ jobs:
           VALIDATE_ALL_CODEBASE: false
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VALIDATE_HTML: false

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,13 +3,13 @@
 # SPDX-License-Identifier: MIT
 
 ---
-name: ktlint
+name: super-linter
 
 on:
   pull_request:
 
 jobs:
-  lint:
+  super-linter:
     runs-on: ubuntu-latest
 
     permissions:
@@ -32,3 +32,4 @@ jobs:
           DEFAULT_BRANCH: main
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VALIDATE_HTML: false
+          FILTER_REGEX_EXCLUDE: ".*src/test/resources.*"


### PR DESCRIPTION
Since we are not writing html and it creates issues with sample reports we should disable the linter.
Also this disables linting for test in src/test/resources.