### PR TITLE
Feature/71 implement hover action

### DIFF
--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -1,0 +1,35 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Tim Herzig <tim.herzig@hotmail.com>
+
+package com.amos.pitmutationmate.pitmutationmate.actions
+
+import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseMotionListener
+import com.intellij.openapi.editor.markup.RangeHighlighter
+import com.intellij.openapi.project.Project
+
+class HoverAction(editor: Editor, hoverHighlighter: RangeHighlighter) : EditorMouseMotionListener {
+    var editor: Editor = editor;
+    var hoverHighlighter: RangeHighlighter = hoverHighlighter;
+    fun hoverActionExample(editor: Editor) {
+        this.editor = editor;
+        this.editor.addEditorMouseMotionListener(this)
+    }
+
+    override fun mouseMoved(e: EditorMouseEvent) {
+        val project: Project? = this.editor.project
+    }
+
+    fun getCurrentWord() {
+        return
+    }
+
+    fun getCurrentLine() {
+        return
+    }
+
+    fun showHoverMessage(editor: Editor, message: String) {
+        return
+    }
+}

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -3,11 +3,15 @@
 
 package com.amos.pitmutationmate.pitmutationmate.actions
 
+import com.amos.pitmutationmate.pitmutationmate.reporting.XMLListener
+import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
 import com.intellij.codeInsight.hint.HintManager
 import com.intellij.codeInsight.hint.HintManagerImpl
 import com.intellij.codeInsight.hint.HintUtil
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.event.EditorMouseEvent
+import com.intellij.openapi.editor.event.EditorMouseListener
 import com.intellij.openapi.editor.event.EditorMouseMotionListener
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
@@ -16,32 +20,56 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.ui.LightweightHint
 import com.intellij.util.ui.accessibility.AccessibleContextUtil
 import java.awt.Point
+import java.util.*
 import javax.swing.JComponent
 
-class HoverAction(editor: Editor) : EditorMouseMotionListener {
-    private var editor: Editor = editor;
-    fun hoverActionExample(editor: Editor) {
-        this.editor = editor;
-        this.editor.addEditorMouseMotionListener(this)
+class HoverAction(private val editor: Editor, private val result: XMLParser.ResultData) {
+    fun addHoverAction() {
+//        this.editor.addEditorMouseMotionListener(MouseMotion())
+        this.editor.addEditorMouseListener(MouseClick())
     }
 
-    override fun mouseMoved(e: EditorMouseEvent) {
-        val project: Project = this.editor.project ?: return
-        val psiFile: PsiFile = PsiDocumentManager.getInstance(project).getPsiFile(this.editor.document) ?: return
+    inner class MouseMotion() : EditorMouseMotionListener {
+        override fun mouseMoved(event: EditorMouseEvent) {
+            println("Mouse moved")
+            showHoverMessage(event.mouseEvent.point)
+        }
+    }
 
-        val offset: Int = editor.caretModel.offset
+    inner class MouseClick() : EditorMouseListener {
+        override fun mouseClicked(event: EditorMouseEvent) {
+            println("Mouse clicked at point: ${event.mouseEvent.point}")
+            showHoverMessage(event.mouseEvent.point)
+        }
+    }
+
+    fun buildHoverMessage(): String? {
+        val project: Project = this.editor.project ?: return null
+        val psiFile: PsiFile = PsiDocumentManager.getInstance(project).getPsiFile(this.editor.document) ?: return null
+
+        val offset: Int = this.editor.caretModel.offset
+        val line: Int = this.editor.caretModel.visualPosition.getLine() + 1
         PsiTreeUtil.findElementOfClassAtOffset(psiFile, offset, psiFile.javaClass, false)
-        val line = editor.caretModel.visualPosition.getLine() + 1
-        showHoverMessage(this.editor, "PiTest: offset: $offset, line: $line")
-    }
 
-    fun showHoverMessage(editor: Editor, message: String) {
+        for (r in this.result.mutationResults) {
+            if (r.lineNumber == line) {
+                val color: String = if (r.detected) "dark-green" else "dark-pink"
+                return "PiTest: selected offset: $offset, selected line: $line \n" +
+                        "The color of this line is $color"
+            }
+        }
+
+        return null
+    }
+    fun showHoverMessage(point: Point) {
+        val message: String = buildHoverMessage() ?: return
         val hintManager: HintManagerImpl = HintManagerImpl.getInstanceImpl()
         val label: JComponent = HintUtil.createInformationLabel(message, null, null, null)
-        AccessibleContextUtil.setName(label, "Message")
+        AccessibleContextUtil.setName(label, "PiTest")
         val hint: LightweightHint = LightweightHint(label)
-        val point: Point = HintManagerImpl.getHintPosition(hint, editor, editor.caretModel.visualPosition, 1)
+//        val p: Point = HintManagerImpl.getHintPosition(hint, this.editor, this.editor.caretModel.visualPosition, 1)
+        val p: Point = HintManagerImpl.getHintPosition(hint, this.editor, this.editor.xyToVisualPosition(point), 1)
         val flags: Int = HintManager.HIDE_BY_ANY_KEY or HintManager.HIDE_BY_TEXT_CHANGE or HintManager.HIDE_BY_SCROLLING
-        hintManager.showEditorHint(hint, editor, point, flags, 0, true, 1)
+        hintManager.showEditorHint(hint, this.editor, p, flags, 0, true, 1)
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -50,7 +50,7 @@ class HoverAction(private val editor: Editor, private val result: XMLParser.Resu
             if (r.lineNumber == line) {
                 val color: String = if (r.detected) "dark-green" else "dark-pink"
                 return "PiTest: selected offset: $offset, selected line: $line \n" +
-                        "The color of this line is $color"
+                    "The color of this line is $color"
             }
         }
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -10,7 +10,6 @@ import com.intellij.codeInsight.hint.HintUtil
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.openapi.editor.event.EditorMouseListener
-//import com.intellij.openapi.editor.event.EditorMouseMotionListener
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -3,33 +3,45 @@
 
 package com.amos.pitmutationmate.pitmutationmate.actions
 
+import com.intellij.codeInsight.hint.HintManager
+import com.intellij.codeInsight.hint.HintManagerImpl
+import com.intellij.codeInsight.hint.HintUtil
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.openapi.editor.event.EditorMouseMotionListener
-import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.project.Project
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import com.intellij.psi.util.PsiTreeUtil
+import com.intellij.ui.LightweightHint
+import com.intellij.util.ui.accessibility.AccessibleContextUtil
+import java.awt.Point
+import javax.swing.JComponent
 
-class HoverAction(editor: Editor, hoverHighlighter: RangeHighlighter) : EditorMouseMotionListener {
-    var editor: Editor = editor;
-    var hoverHighlighter: RangeHighlighter = hoverHighlighter;
+class HoverAction(editor: Editor) : EditorMouseMotionListener {
+    private var editor: Editor = editor;
     fun hoverActionExample(editor: Editor) {
         this.editor = editor;
         this.editor.addEditorMouseMotionListener(this)
     }
 
     override fun mouseMoved(e: EditorMouseEvent) {
-        val project: Project? = this.editor.project
-    }
+        val project: Project = this.editor.project ?: return
+        val psiFile: PsiFile = PsiDocumentManager.getInstance(project).getPsiFile(this.editor.document) ?: return
 
-    fun getCurrentWord() {
-        return
-    }
-
-    fun getCurrentLine() {
-        return
+        val offset: Int = editor.caretModel.offset
+        PsiTreeUtil.findElementOfClassAtOffset(psiFile, offset, psiFile.javaClass, false)
+        val line = editor.caretModel.visualPosition.getLine() + 1
+        showHoverMessage(this.editor, "PiTest: offset: $offset, line: $line")
     }
 
     fun showHoverMessage(editor: Editor, message: String) {
-        return
+        val hintManager: HintManagerImpl = HintManagerImpl.getInstanceImpl()
+        val label: JComponent = HintUtil.createInformationLabel(message, null, null, null)
+        AccessibleContextUtil.setName(label, "Message")
+        val hint: LightweightHint = LightweightHint(label)
+        val point: Point = HintManagerImpl.getHintPosition(hint, editor, editor.caretModel.visualPosition, 1)
+        val flags: Int = HintManager.HIDE_BY_ANY_KEY or HintManager.HIDE_BY_TEXT_CHANGE or HintManager.HIDE_BY_SCROLLING
+        hintManager.showEditorHint(hint, editor, point, flags, 0, true, 1)
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -3,13 +3,11 @@
 
 package com.amos.pitmutationmate.pitmutationmate.actions
 
-import com.amos.pitmutationmate.pitmutationmate.reporting.XMLListener
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
 import com.intellij.codeInsight.hint.HintManager
 import com.intellij.codeInsight.hint.HintManagerImpl
 import com.intellij.codeInsight.hint.HintUtil
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.LogicalPosition
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.openapi.editor.event.EditorMouseListener
 import com.intellij.openapi.editor.event.EditorMouseMotionListener
@@ -20,25 +18,22 @@ import com.intellij.psi.util.PsiTreeUtil
 import com.intellij.ui.LightweightHint
 import com.intellij.util.ui.accessibility.AccessibleContextUtil
 import java.awt.Point
-import java.util.*
 import javax.swing.JComponent
+
 
 class HoverAction(private val editor: Editor, private val result: XMLParser.ResultData) {
     fun addHoverAction() {
-//        this.editor.addEditorMouseMotionListener(MouseMotion())
         this.editor.addEditorMouseListener(MouseClick())
     }
 
     inner class MouseMotion() : EditorMouseMotionListener {
         override fun mouseMoved(event: EditorMouseEvent) {
-            println("Mouse moved")
             showHoverMessage(event.mouseEvent.point)
         }
     }
 
     inner class MouseClick() : EditorMouseListener {
         override fun mouseClicked(event: EditorMouseEvent) {
-            println("Mouse clicked at point: ${event.mouseEvent.point}")
             showHoverMessage(event.mouseEvent.point)
         }
     }
@@ -67,7 +62,6 @@ class HoverAction(private val editor: Editor, private val result: XMLParser.Resu
         val label: JComponent = HintUtil.createInformationLabel(message, null, null, null)
         AccessibleContextUtil.setName(label, "PiTest")
         val hint: LightweightHint = LightweightHint(label)
-//        val p: Point = HintManagerImpl.getHintPosition(hint, this.editor, this.editor.caretModel.visualPosition, 1)
         val p: Point = HintManagerImpl.getHintPosition(hint, this.editor, this.editor.xyToVisualPosition(point), 1)
         val flags: Int = HintManager.HIDE_BY_ANY_KEY or HintManager.HIDE_BY_TEXT_CHANGE or HintManager.HIDE_BY_SCROLLING
         hintManager.showEditorHint(hint, this.editor, p, flags, 0, true, 1)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -20,7 +20,6 @@ import com.intellij.util.ui.accessibility.AccessibleContextUtil
 import java.awt.Point
 import javax.swing.JComponent
 
-
 class HoverAction(private val editor: Editor, private val result: XMLParser.ResultData) {
     fun addHoverAction() {
         this.editor.addEditorMouseListener(MouseClick())
@@ -56,6 +55,7 @@ class HoverAction(private val editor: Editor, private val result: XMLParser.Resu
 
         return null
     }
+
     fun showHoverMessage(point: Point) {
         val message: String = buildHoverMessage() ?: return
         val hintManager: HintManagerImpl = HintManagerImpl.getInstanceImpl()

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -25,19 +25,20 @@ class HoverAction(private val editor: Editor, private val result: XMLParser.Resu
         this.editor.addEditorMouseListener(MouseClick())
     }
 
-    inner class MouseMotion() : EditorMouseMotionListener {
-        override fun mouseMoved(event: EditorMouseEvent) {
-            showHoverMessage(event.mouseEvent.point)
-        }
-    }
+//    Currently not in use, but could be used for hover behaviour
+//    inner class MouseMotion : EditorMouseMotionListener {
+//        override fun mouseMoved(event: EditorMouseEvent) {
+//            showHoverMessage(event.mouseEvent.point)
+//        }
+//    }
 
-    inner class MouseClick() : EditorMouseListener {
+    inner class MouseClick : EditorMouseListener {
         override fun mouseClicked(event: EditorMouseEvent) {
             showHoverMessage(event.mouseEvent.point)
         }
     }
 
-    fun buildHoverMessage(): String? {
+    private fun buildHoverMessage(): String? {
         val project: Project = this.editor.project ?: return null
         val psiFile: PsiFile = PsiDocumentManager.getInstance(project).getPsiFile(this.editor.document) ?: return null
 
@@ -61,7 +62,7 @@ class HoverAction(private val editor: Editor, private val result: XMLParser.Resu
         val hintManager: HintManagerImpl = HintManagerImpl.getInstanceImpl()
         val label: JComponent = HintUtil.createInformationLabel(message, null, null, null)
         AccessibleContextUtil.setName(label, "PiTest")
-        val hint: LightweightHint = LightweightHint(label)
+        val hint = LightweightHint(label)
         val p: Point = HintManagerImpl.getHintPosition(hint, this.editor, this.editor.xyToVisualPosition(point), 1)
         val flags: Int = HintManager.HIDE_BY_ANY_KEY or HintManager.HIDE_BY_TEXT_CHANGE or HintManager.HIDE_BY_SCROLLING
         hintManager.showEditorHint(hint, this.editor, p, flags, 0, true, 1)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -23,6 +23,7 @@ import javax.swing.JComponent
 class HoverAction(private val editor: Editor, private val result: XMLParser.ResultData) {
     fun addHoverAction() {
         this.editor.addEditorMouseListener(MouseClick())
+//        TODO: Decide on which action suits the plugin the best --> when choice is made refactor to only use one
 //        this.editor.addEditorMouseMotionListener(MouseMotion())
     }
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/HoverAction.kt
@@ -10,7 +10,7 @@ import com.intellij.codeInsight.hint.HintUtil
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.event.EditorMouseEvent
 import com.intellij.openapi.editor.event.EditorMouseListener
-import com.intellij.openapi.editor.event.EditorMouseMotionListener
+//import com.intellij.openapi.editor.event.EditorMouseMotionListener
 import com.intellij.openapi.project.Project
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -11,7 +11,9 @@ import com.intellij.execution.ProgramRunnerUtil
 import com.intellij.execution.RunManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.editor.Editor
+import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.project.Project
+import com.intellij.util.ui.JBUI.CurrentTheme.Tree.Hover
 import java.nio.file.Paths
 
 abstract class RunConfigurationAction : AnAction() {
@@ -36,6 +38,8 @@ abstract class RunConfigurationAction : AnAction() {
             val dir = Paths.get("build", "reports", "pitest", "test", "mutations.xml")
             var xmlListener = XMLListener(dir, editor)
             xmlListener.listen()
+            val ha: HoverAction = HoverAction(editor)
+            ha.hoverActionExample(editor)
         }
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -11,9 +11,7 @@ import com.intellij.execution.ProgramRunnerUtil
 import com.intellij.execution.RunManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.editor.Editor
-import com.intellij.openapi.editor.markup.RangeHighlighter
 import com.intellij.openapi.project.Project
-import com.intellij.util.ui.JBUI.CurrentTheme.Tree.Hover
 import java.nio.file.Paths
 
 abstract class RunConfigurationAction : AnAction() {
@@ -36,7 +34,7 @@ abstract class RunConfigurationAction : AnAction() {
         if (editor != null) {
             // TODO: use actual XML report directories. This currently uses a placeholder test folder
             val dir = Paths.get("build", "reports", "pitest", "test", "mutations.xml")
-            var xmlListener = XMLListener(dir, editor)
+            val xmlListener = XMLListener(dir, editor)
             xmlListener.listen()
             val ha: HoverAction = HoverAction(editor, xmlListener.getResult())
             ha.addHoverAction()

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -38,8 +38,8 @@ abstract class RunConfigurationAction : AnAction() {
             val dir = Paths.get("build", "reports", "pitest", "test", "mutations.xml")
             var xmlListener = XMLListener(dir, editor)
             xmlListener.listen()
-            val ha: HoverAction = HoverAction(editor)
-            ha.hoverActionExample(editor)
+            val ha: HoverAction = HoverAction(editor, xmlListener.getResult())
+            ha.addHoverAction()
         }
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLListener.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLListener.kt
@@ -18,9 +18,13 @@ class XMLListener(private var dir: Path, private var editor: Editor) {
         displayResults()
     }
 
+    fun getResult(): XMLParser.ResultData {
+        return this.result
+    }
+
     private fun loadResults() {
         val parser: XMLParser = XMLParser()
-        result = parser.loadResultsFromXmlReport(this.dir.toString())
+        this.result = parser.loadResultsFromXmlReport(this.dir.toString())
     }
 
     fun displayResults() {


### PR DESCRIPTION
- "Hover action" now changed into more of a "click action", my reasoning for this is that the native hover action in JetBrains is related to the language used and code documentation.
- The action is activated when a test is run (currently from the gutter icon) and when clicking on lines that have color annotations in the gutter it shows sample information -> currently line number and which color the gutter is.
- A small bug/inconvenience is that the area where clicks are allowed includes the gutter, as this is also a method of adding break points for testing two actions get triggered -> add break point and show the hover information.