### PR TITLE
Feature/98 connect test report data to result window

### DIFF
--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -12,13 +12,12 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.components.JBLabel
-import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentFactory
 import javax.swing.JPanel
 
 internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        //TODO: fetch most recent results to display (e.g. when opening up the editor and previous Pitest runs are saved)
+        // TODO: fetch most recent results to display (e.g. when opening up the editor and previous Pitest runs are saved)
         val lastCoverageReport: XMLParser.CoverageReport? = null
         val latestPiTestReport = if (lastCoverageReport == null) {
             ContentFactory.getInstance().createContent(displayErrorMessage(), "Latest Result", false)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -35,7 +35,7 @@ internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
     }
 
     fun updateReport(toolWindow: ToolWindow, newCoverageReport: XMLParser.CoverageReport) {
-        toolWindow.contentManager.getContent(0)?.component = LatestPiTestReport(newCoverageReport)
+        toolWindow.contentManager.findContent("Latest Result").component = LatestPiTestReport(newCoverageReport)
     }
 
     private fun displayErrorMessage(): JPanel {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -11,11 +11,20 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.content.Content
 import com.intellij.ui.content.ContentFactory
+import javax.swing.JPanel
 
-internal class MutationTestToolWindowFactory() : ToolWindowFactory, DumbAware {
+internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
-        val latestPiTestReport = ContentFactory.getInstance().createContent(LatestPiTestReport(), "Latest Result", false)
+        //TODO: fetch most recent results to display (e.g. when opening up the editor and previous Pitest runs are saved)
+        val lastCoverageReport: XMLParser.CoverageReport? = null
+        val latestPiTestReport = if (lastCoverageReport == null) {
+            ContentFactory.getInstance().createContent(displayErrorMessage(), "Latest Result", false)
+        } else {
+            ContentFactory.getInstance().createContent(LatestPiTestReport(lastCoverageReport), "Latest Result", false)
+        }
         val table = ContentFactory.getInstance().createContent(JTreeTable(), "Mutationtest Coverage", false)
         val lineChart = ContentFactory.getInstance().createContent(LineGraph(), "Line Chart", false)
         val barChart = ContentFactory.getInstance().createContent(BarGraph(), "Bar Chart", false)
@@ -26,7 +35,18 @@ internal class MutationTestToolWindowFactory() : ToolWindowFactory, DumbAware {
         toolWindow.contentManager.addContent(barChart)
     }
 
-    fun updateReport(toolWindow: ToolWindow, coverageReport: XMLParser.CoverageReport) {
-        toolWindow.contentManager.getContent(0)?.component = LatestPiTestReport(coverageReport)
+    fun updateReport(toolWindow: ToolWindow, newCoverageReport: XMLParser.CoverageReport) {
+        toolWindow.contentManager.getContent(0)?.component = LatestPiTestReport(newCoverageReport)
+    }
+
+    private fun displayErrorMessage(): JPanel {
+        val panel = JPanel()
+
+        // Displaying an error message in the panel
+        val errorMessage = "No results to display yet."
+        val errorLabel = JBLabel(errorMessage)
+        panel.add(errorLabel)
+
+        return panel
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2023
 package com.amos.pitmutationmate.pitmutationmate
 
+import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
 import com.amos.pitmutationmate.pitmutationmate.visualization.BarGraph
 import com.amos.pitmutationmate.pitmutationmate.visualization.LatestPiTestReport
 import com.amos.pitmutationmate.pitmutationmate.visualization.LineGraph
@@ -12,7 +13,7 @@ import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
 import com.intellij.ui.content.ContentFactory
 
-internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
+internal class MutationTestToolWindowFactory() : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         val latestPiTestReport = ContentFactory.getInstance().createContent(LatestPiTestReport(), "Latest Result", false)
         val table = ContentFactory.getInstance().createContent(JTreeTable(), "Mutationtest Coverage", false)
@@ -23,5 +24,9 @@ internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
         toolWindow.contentManager.addContent(table)
         toolWindow.contentManager.addContent(lineChart)
         toolWindow.contentManager.addContent(barChart)
+    }
+
+    fun updateReport(toolWindow: ToolWindow, coverageReport: XMLParser.CoverageReport) {
+        toolWindow.contentManager.getContent(0)?.component = LatestPiTestReport(coverageReport)
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -44,6 +44,7 @@ abstract class RunConfigurationAction : AnAction() {
         }
 
         // Update visualisation with mock results
+        // TODO: replace this by real results extracted by the HTMLParser
         val toolWindow: ToolWindow? = ToolWindowManager.getInstance(project).getToolWindow("Pitest")
         val mutationTestToolWindowFactorySingleton = MutationTestToolWindowFactory()
         val coverageReport: XMLParser.CoverageReport = XMLParser.CoverageReport(

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -14,10 +14,10 @@ import com.intellij.execution.RunManager
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
-import java.nio.file.Paths
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowManager
 import org.jetbrains.kotlin.idea.gradleTooling.get
+import java.nio.file.Paths
 
 abstract class RunConfigurationAction : AnAction() {
     fun updateAndExecuteRunConfig(classFQN: String?, project: Project, editor: Editor?) {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -3,9 +3,11 @@
 
 package com.amos.pitmutationmate.pitmutationmate.actions
 
+import com.amos.pitmutationmate.pitmutationmate.MutationTestToolWindowFactory
 import com.amos.pitmutationmate.pitmutationmate.configuration.RunConfiguration
 import com.amos.pitmutationmate.pitmutationmate.configuration.RunConfigurationType
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLListener
+import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
 import com.intellij.execution.ExecutorRegistry
 import com.intellij.execution.ProgramRunnerUtil
 import com.intellij.execution.RunManager
@@ -13,6 +15,9 @@ import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.project.Project
 import java.nio.file.Paths
+import com.intellij.openapi.wm.ToolWindow
+import com.intellij.openapi.wm.ToolWindowManager
+import org.jetbrains.kotlin.idea.gradleTooling.get
 
 abstract class RunConfigurationAction : AnAction() {
     fun updateAndExecuteRunConfig(classFQN: String?, project: Project, editor: Editor?) {
@@ -37,5 +42,24 @@ abstract class RunConfigurationAction : AnAction() {
             var xmlListener = XMLListener(dir, editor)
             xmlListener.listen()
         }
+
+        val coverageReport: XMLParser.CoverageReport = XMLParser.CoverageReport(
+            lineCoveragePercentage = 80,
+            lineCoverageTextRatio = "160/200",
+            mutationCoveragePercentage = 50,
+            mutationCoverageTextRatio = "100/200",
+            testStrengthPercentage = 40,
+            testStrengthTextRatio = "80/200"
+        )
+
+        // Update visualisation
+        println("Updating visualisation...")
+        val toolWindow: ToolWindow? = ToolWindowManager.getInstance(project).getToolWindow("Pitest")
+        val mutationTestToolWindowFactorySingleton = MutationTestToolWindowFactory()
+        if (toolWindow != null) {
+            println("Updating report...")
+            mutationTestToolWindowFactorySingleton.updateReport(toolWindow, coverageReport)
+        }
+        println("Visualisation updated.")
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -43,6 +43,9 @@ abstract class RunConfigurationAction : AnAction() {
             xmlListener.listen()
         }
 
+        // Update visualisation with mock results
+        val toolWindow: ToolWindow? = ToolWindowManager.getInstance(project).getToolWindow("Pitest")
+        val mutationTestToolWindowFactorySingleton = MutationTestToolWindowFactory()
         val coverageReport: XMLParser.CoverageReport = XMLParser.CoverageReport(
             lineCoveragePercentage = 80,
             lineCoverageTextRatio = "160/200",
@@ -51,15 +54,8 @@ abstract class RunConfigurationAction : AnAction() {
             testStrengthPercentage = 40,
             testStrengthTextRatio = "80/200"
         )
-
-        // Update visualisation
-        println("Updating visualisation...")
-        val toolWindow: ToolWindow? = ToolWindowManager.getInstance(project).getToolWindow("Pitest")
-        val mutationTestToolWindowFactorySingleton = MutationTestToolWindowFactory()
         if (toolWindow != null) {
-            println("Updating report...")
             mutationTestToolWindowFactorySingleton.updateReport(toolWindow, coverageReport)
         }
-        println("Visualisation updated.")
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLParser.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLParser.kt
@@ -103,14 +103,7 @@ class XMLParser {
 
     data class ResultData(
         // placeholder field for coverage report results to be displayed in visualisation
-        val coverageReport: CoverageReport = CoverageReport(
-            lineCoveragePercentage = 80,
-            lineCoverageTextRatio = "160/200",
-            mutationCoveragePercentage = 50,
-            mutationCoverageTextRatio = "100/200",
-            testStrengthPercentage = 40,
-            testStrengthTextRatio = "80/200"
-        ),
+        val coverageReport: CoverageReport? = null,
         val mutationResults: MutableList<MutationResult> = mutableListOf()
     ) {
         fun addMutationResult(mutationResult: MutationResult) {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLParser.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLParser.kt
@@ -102,6 +102,15 @@ class XMLParser {
     }
 
     data class ResultData(
+        // placeholder field for coverage report results to be displayed in visualisation
+        val coverageReport: CoverageReport = CoverageReport(
+            lineCoveragePercentage = 80,
+            lineCoverageTextRatio = "160/200",
+            mutationCoveragePercentage = 50,
+            mutationCoverageTextRatio = "100/200",
+            testStrengthPercentage = 40,
+            testStrengthTextRatio = "80/200"
+        ),
         val mutationResults: MutableList<MutationResult> = mutableListOf()
     ) {
         fun addMutationResult(mutationResult: MutationResult) {
@@ -128,5 +137,14 @@ class XMLParser {
         val blocks: List<Int>,
         val killingTest: String,
         val description: String
+    )
+
+    data class CoverageReport(
+        val lineCoveragePercentage: Int,
+        val lineCoverageTextRatio: String,
+        val mutationCoveragePercentage: Int,
+        val mutationCoverageTextRatio: String,
+        val testStrengthPercentage: Int,
+        val testStrengthTextRatio: String
     )
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/LatestPiTestReport.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/LatestPiTestReport.kt
@@ -4,6 +4,7 @@
 
 package com.amos.pitmutationmate.pitmutationmate.visualization
 
+import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
 import com.intellij.ui.components.JBLabel
 import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.table.JBTable
@@ -18,12 +19,21 @@ import javax.swing.ListSelectionModel
 import javax.swing.table.DefaultTableCellRenderer
 import javax.swing.table.DefaultTableModel
 
-class LatestPiTestReport : JPanel() {
+class LatestPiTestReport(
+    coverageReport: XMLParser.CoverageReport = XMLParser.CoverageReport(
+        lineCoveragePercentage = 0,
+        lineCoverageTextRatio = "",
+        mutationCoveragePercentage = 0,
+        mutationCoverageTextRatio = "",
+        testStrengthPercentage = 0,
+        testStrengthTextRatio = ""
+    )
+) : JPanel() {
 
     init {
-        val lineCoverageBar = CustomProgressBar(30, "1/5")
-        val mutationCoverageBar = CustomProgressBar(50, "3000/30000")
-        val testStrengthBar = CustomProgressBar(93, "200/2000")
+        val lineCoverageBar = CustomProgressBar(coverageReport.lineCoveragePercentage, coverageReport.lineCoverageTextRatio)
+        val mutationCoverageBar = CustomProgressBar(coverageReport.mutationCoveragePercentage, coverageReport.mutationCoverageTextRatio)
+        val testStrengthBar = CustomProgressBar(coverageReport.testStrengthPercentage, coverageReport.testStrengthTextRatio)
 
         val data = arrayOf(
             arrayOf(getLabel("Class Name"), getLabel("Test.java")),


### PR DESCRIPTION
- feed relevant results from pitest report to result visualisation window in IDE (for now, just the "Latest Result" tab)
- since the visualisation is reliant on "coverage" results (e.g. line coverage, mutation coverage etc.) which are _not_ parsed by the XML parser, a placeholder data class `CoverageReport` in the XML parser is defined. This needs to be refactored once the HTML Parser is merged, perhaps a small ticket for the next sprint (@emuguy1 @Felix-012)
- workflow: a mock set of results in `RunConfigurationAction.kt` is used to update the "Latest Result" panel in the corresponding`ToolWindow` instance