### PR TITLE
Set Intellij version to the newest version

### DIFF
--- a/pitmutationmate/build.gradle.kts
+++ b/pitmutationmate/build.gradle.kts
@@ -36,7 +36,7 @@ repositories {
 // Configure Gradle IntelliJ Plugin
 // Read more: https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html
 intellij {
-    version.set("2023.1")
+    version.set("2023.3")
     type.set("IC") // Target IDE Platform
     plugins.set(listOf("org.jetbrains.kotlin", "com.intellij.java"))
 }


### PR DESCRIPTION
Should download and launch version 2023.3 of IntelliJ when building and running the plugin in the development IDE. If the theme does not change a short guide to this has been added to the Wiki.