### PR TITLE
Add External Annotator to get mutation results in problems window

### DIFF
--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/ContextMenuAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/ContextMenuAction.kt
@@ -31,7 +31,7 @@ class ContextMenuAction : RunConfigurationAction() {
                 }
 
                 logger.info("ContextMenuAction: selected class is $classFQN.")
-                updateAndExecuteRunConfig(classFQN, e.project!!, editor)
+                updateAndExecuteRunConfig(classFQN, e.project!!)
             }
         }
         if (e.place == "ProjectViewPopup") {
@@ -49,7 +49,7 @@ class ContextMenuAction : RunConfigurationAction() {
                 }
             }
             logger.info("ContextMenuAction: selected classes are $classFQNs.")
-            updateAndExecuteRunConfig(classFQNs, e.project!!, editor)
+            updateAndExecuteRunConfig(classFQNs, e.project!!)
         }
     }
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/GutterAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/GutterAction.kt
@@ -9,6 +9,6 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 class GutterAction(private val fqn: String) : RunConfigurationAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val editor = e.getData(CommonDataKeys.EDITOR)
-        updateAndExecuteRunConfig(fqn, e.project!!, editor)
+        updateAndExecuteRunConfig(fqn, e.project!!)
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/ToolMenuAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/ToolMenuAction.kt
@@ -9,6 +9,6 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 class ToolMenuAction : RunConfigurationAction() {
     override fun actionPerformed(e: AnActionEvent) {
         val editor = e.getData(CommonDataKeys.EDITOR)
-        updateAndExecuteRunConfig("", e.project!!, editor)
+        updateAndExecuteRunConfig("", e.project!!)
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotator.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotator.kt
@@ -1,0 +1,76 @@
+package com.amos.pitmutationmate.pitmutationmate.editor
+
+import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
+import com.amos.pitmutationmate.pitmutationmate.services.MutationResultService
+import com.amos.pitmutationmate.pitmutationmate.utils.PitestSeverity
+import com.amos.pitmutationmate.pitmutationmate.visualization.HighlightGutterRenderer
+import com.intellij.lang.annotation.AnnotationHolder
+import com.intellij.lang.annotation.ExternalAnnotator
+import com.intellij.openapi.components.service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.util.TextRange
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+
+class MutationsAnnotator :
+    ExternalAnnotator<List<XMLParser.MutationResult>, Map<Int, List<XMLParser.MutationResult>>>() {
+
+    object Util {
+        private fun isWhitespace(document: Document, offset: Int, endLineOffset: Int): Boolean {
+            return offset < endLineOffset && Character.isWhitespace(document.charsSequence[offset])
+        }
+
+        fun getContentOffset(document: Document, lineNr: Int): TextRange {
+            val lineStartOffset = document.getLineStartOffset(lineNr)
+            val lineEndOffset = document.getLineEndOffset(lineNr)
+            var contentStartOffset = lineStartOffset
+            // Find the first non-whitespace character to exclude the leading indentation
+            while (isWhitespace(document, contentStartOffset, lineEndOffset)) {
+                contentStartOffset++
+            }
+            return TextRange(contentStartOffset, lineEndOffset)
+        }
+
+        fun getMessage(mutationResults: List<XMLParser.MutationResult>, isTooltip: Boolean): String {
+            // TODO: add icon, link mutation result and improve formatting
+            val separator = if (isTooltip) "<br/>" else ", "
+            return mutationResults.mapIndexed { index, it -> "${index + 1}. ${it.description} → ${it.status}" }
+                .joinToString(separator)
+        }
+    }
+
+    companion object {
+        private val log = Logger.getInstance(MutationsAnnotator::class.java)
+    }
+
+    override fun collectInformation(file: PsiFile): List<XMLParser.MutationResult> {
+        log.debug("collectInformation")
+        val resultGenerator = file.project.service<MutationResultService>()
+        return resultGenerator.getMutationResult().mutationResults.filter { it.sourceFile == file.name }
+    }
+
+    override fun doAnnotate(
+        annotationResult: List<XMLParser.MutationResult>
+    ): Map<Int, List<XMLParser.MutationResult>> {
+        log.debug("doAnnotate")
+
+        // map fileResults by lineNumber into a map
+        return annotationResult.groupBy { it.lineNumber }
+    }
+
+    override fun apply(
+        file: PsiFile, annotationResult: Map<Int, List<XMLParser.MutationResult>>, holder: AnnotationHolder
+    ) {
+        log.debug("apply")
+        val document: Document = PsiDocumentManager.getInstance(file.project).getDocument(file) ?: return
+
+        for (r in annotationResult) {
+            val lineRange = Util.getContentOffset(document, r.key - 1)
+            val severity = PitestSeverity.fromMutationResults(r.value)
+            holder.newAnnotation(severity.highlightSeverity(), Util.getMessage(r.value, false)).range(lineRange)
+                .tooltip(Util.getMessage(r.value, true)).highlightType(severity.highlightType())
+                .gutterIconRenderer(HighlightGutterRenderer(severity.gutterIcon())).create()
+        }
+    }
+}

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotator.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotator.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
+
 package com.amos.pitmutationmate.pitmutationmate.editor
 
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotator.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotator.kt
@@ -63,7 +63,9 @@ class MutationsAnnotator :
     }
 
     override fun apply(
-        file: PsiFile, annotationResult: Map<Int, List<XMLParser.MutationResult>>, holder: AnnotationHolder
+        file: PsiFile,
+        annotationResult: Map<Int, List<XMLParser.MutationResult>>,
+        holder: AnnotationHolder
     ) {
         log.debug("apply")
         val document: Document = PsiDocumentManager.getInstance(file.project).getDocument(file) ?: return

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/BasePitestExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/BasePitestExecutor.kt
@@ -3,6 +3,7 @@
 
 package com.amos.pitmutationmate.pitmutationmate.execution
 
+import com.amos.pitmutationmate.pitmutationmate.services.ReportPathGeneratorService
 import com.amos.pitmutationmate.pitmutationmate.services.UdpMessagingServer
 import com.intellij.execution.configurations.GeneralCommandLine
 import com.intellij.execution.process.ProcessAdapter
@@ -13,6 +14,7 @@ import com.intellij.execution.process.ProcessTerminatedListener
 import com.intellij.openapi.components.service
 import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.project.Project
+import java.nio.file.Path
 
 abstract class BasePitestExecutor {
 
@@ -27,7 +29,9 @@ abstract class BasePitestExecutor {
         val messagingServer = project.service<UdpMessagingServer>()
         messagingServer.startServer(classFQN) // Start the UDP server
 
-        val commandLine = buildCommandLine(executable, overrideTaskName, project.basePath!!, classFQN, messagingServer.port)
+        val reportDir = project.service<ReportPathGeneratorService>().getReportPath()
+
+        val commandLine = buildCommandLine(executable, overrideTaskName, project.basePath!!, classFQN, reportDir, messagingServer.port)
         log.debug("BasePitestExecutor: executeTask: commandLine: $commandLine")
         val processHandler = createProcessHandler(commandLine)
         processHandler.addProcessListener(object : ProcessAdapter() {
@@ -45,6 +49,7 @@ abstract class BasePitestExecutor {
         overrideTaskName: String?,
         projectDir: String,
         classFQN: String?,
+        reportDir: Path,
         port: Int
     ): GeneralCommandLine
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutor.kt
@@ -5,6 +5,7 @@ package com.amos.pitmutationmate.pitmutationmate.execution
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import java.io.File
+import java.nio.file.Path
 
 class GradleTaskExecutor : BasePitestExecutor() {
     companion object {
@@ -23,6 +24,7 @@ class GradleTaskExecutor : BasePitestExecutor() {
         overrideTaskName: String?,
         projectDir: String,
         classFQN: String?,
+        reportDir: Path,
         port: Int
     ): GeneralCommandLine {
         val commandLine = GeneralCommandLine()
@@ -47,19 +49,20 @@ class GradleTaskExecutor : BasePitestExecutor() {
             commandLine.addParameters(UNIX_FIRST_PARAMETER, gradleExecutable, taskName)
         }
 
-        commandLine.addParameters(getPitestOverrideParameters(classFQN, port))
+        commandLine.addParameters(getPitestOverrideParameters(classFQN, port, reportDir))
 
         commandLine.workDirectory = File(projectDir)
         return commandLine
     }
 
-    private fun getPitestOverrideParameters(classFQN: String?, port: Int): List<String> {
+    private fun getPitestOverrideParameters(classFQN: String?, port: Int, reportDir: Path): List<String> {
         val parameters = mutableListOf<String>()
         if (!classFQN.isNullOrEmpty()) {
             parameters.add("-Dpitmutationmate.override.targetClasses=$classFQN")
         }
         parameters.add("-Dpitmutationmate.override.verbose=true")
         parameters.add("-Dpitmutationmate.override.port=$port")
+        parameters.add("-Dpitmutationmate.override.reportDir=${reportDir.toAbsolutePath()}")
         return parameters
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/MavenTaskExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/MavenTaskExecutor.kt
@@ -5,6 +5,7 @@ package com.amos.pitmutationmate.pitmutationmate.execution
 
 import com.intellij.execution.configurations.GeneralCommandLine
 import java.io.File
+import java.nio.file.Path
 
 class MavenTaskExecutor : BasePitestExecutor() {
     private var taskName: String = "org.pitest:pitest-maven:mutationCoverage"
@@ -15,6 +16,7 @@ class MavenTaskExecutor : BasePitestExecutor() {
         overrideTaskName: String?,
         projectDir: String,
         classFQN: String?,
+        reportDir: Path,
         port: Int
     ): GeneralCommandLine {
         val commandLine = GeneralCommandLine()

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/SystemInfo.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/SystemInfo.kt
@@ -5,7 +5,7 @@ package com.amos.pitmutationmate.pitmutationmate.execution
 
 import com.intellij.openapi.util.SystemInfo
 
-interface SystemInfoProvider {
+fun interface SystemInfoProvider {
     fun isWindows(): Boolean
 }
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLListener.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLListener.kt
@@ -3,6 +3,7 @@
 
 package com.amos.pitmutationmate.pitmutationmate.reporting
 
+import com.amos.pitmutationmate.pitmutationmate.visualization.HighlightGutterRenderer
 import com.intellij.openapi.editor.Editor
 import java.nio.file.Path
 import java.nio.file.Paths

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLParser.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLParser.kt
@@ -8,7 +8,7 @@ import java.io.File
 import javax.xml.parsers.DocumentBuilderFactory
 
 class XMLParser {
-    fun loadResultsFromXmlReport(xmlReportPath: String?): ResultData {
+    fun loadResultsFromXmlReport(xmlReportPath: String): ResultData {
         val resultData = ResultData()
         try {
             val documentBuilderFactory = DocumentBuilderFactory.newInstance()
@@ -110,9 +110,7 @@ class XMLParser {
             mutationResults.add(mutationResult)
         }
         fun displayResult(mutationResult: MutationResult) {
-//            val editor =
-//            val color = if (mutationResult.detected) "green" else "red"
-//            HighlightGutterRenderer.GutterHighlighter.addBar(editor, color, mutationResult.lineNumber)
+            // removed in favor of MutationsAnnotator
         }
     }
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/MutationResultService.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/MutationResultService.kt
@@ -11,11 +11,11 @@ import com.intellij.openapi.project.Project
 @Service(Service.Level.PROJECT)
 class MutationResultService(private val project: Project) {
 
-        fun getMutationResult(): XMLParser.ResultData {
-            val reportPathGenerator = project.service<ReportPathGeneratorService>()
-            val dir = reportPathGenerator.getReportMutationsFile()
+    fun getMutationResult(): XMLParser.ResultData {
+        val reportPathGenerator = project.service<ReportPathGeneratorService>()
+        val dir = reportPathGenerator.getReportMutationsFile()
 
-            val parser = XMLParser()
-            return parser.loadResultsFromXmlReport(dir.toString())
-        }
+        val parser = XMLParser()
+        return parser.loadResultsFromXmlReport(dir.toString())
+    }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/MutationResultService.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/MutationResultService.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
+
 package com.amos.pitmutationmate.pitmutationmate.services
 
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/MutationResultService.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/MutationResultService.kt
@@ -1,0 +1,18 @@
+package com.amos.pitmutationmate.pitmutationmate.services
+
+import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.components.service
+import com.intellij.openapi.project.Project
+
+@Service(Service.Level.PROJECT)
+class MutationResultService(private val project: Project) {
+
+        fun getMutationResult(): XMLParser.ResultData {
+            val reportPathGenerator = project.service<ReportPathGeneratorService>()
+            val dir = reportPathGenerator.getReportMutationsFile()
+
+            val parser = XMLParser()
+            return parser.loadResultsFromXmlReport(dir.toString())
+        }
+}

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/ReportPathGeneratorService.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/ReportPathGeneratorService.kt
@@ -49,7 +49,7 @@ class ReportPathGeneratorService(private val project: Project) {
      * Creates the report path if it does not exist yet.
      * @return the report path
      */
-    fun createReportPath(reportPath: Path) : Path {
+    fun createReportPath(reportPath: Path): Path {
         if (!reportPath.exists()) {
             try {
                 reportPath.toFile().mkdirs()

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/ReportPathGeneratorService.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/ReportPathGeneratorService.kt
@@ -1,0 +1,64 @@
+package com.amos.pitmutationmate.pitmutationmate.services
+
+import com.intellij.openapi.components.Service
+import com.intellij.openapi.diagnostic.Logger
+import com.intellij.openapi.project.Project
+import java.nio.file.Path
+import kotlin.io.path.exists
+
+/**
+ * A service that generates the path to the report directory.
+ */
+@Service(Service.Level.PROJECT)
+class ReportPathGeneratorService(private val project: Project) {
+
+    /**
+     * Returns the path to the report directory.
+     * @return the path to the report directory
+     */
+    fun getReportPath(): Path {
+        val projectBasePath = project.basePath ?: ""
+        if (projectBasePath.isEmpty()) {
+            log.warn("Project base path is empty, using current directory as base path")
+        }
+        return Path.of("$projectBasePath/build/reports/pitest/test")
+    }
+
+    /**
+     * Returns the path to mutations.xml.
+     * @return the path to the report file
+     */
+    fun getReportMutationsFile(): Path {
+        val path = getReportPath()
+        return Path.of("$path/mutations.xml")
+    }
+
+    /**
+     * Returns the path to coverage.xml.
+     * @return the path to the report file
+     */
+    fun getReportCoverageFile(): Path {
+        val path = getReportPath()
+        return Path.of("$path/coverage.xml")
+    }
+
+    /**
+     * Creates the report path if it does not exist yet.
+     * @return the report path
+     */
+    fun createReportPath(reportPath: Path) : Path {
+        if (!reportPath.exists()) {
+            try {
+                reportPath.toFile().mkdirs()
+                log.info("Created report path: $reportPath")
+            } catch (e: Exception) {
+                log.error("Could not create report path: $reportPath")
+            }
+        }
+        return reportPath
+    }
+
+    companion object {
+        private val log: Logger = Logger.getInstance(ReportPathGeneratorService::class.java)
+    }
+}

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/ReportPathGeneratorService.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/ReportPathGeneratorService.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
+
 package com.amos.pitmutationmate.pitmutationmate.services
 
 import com.intellij.openapi.components.Service

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/utils/PitestSeverity.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/utils/PitestSeverity.kt
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
+
 package com.amos.pitmutationmate.pitmutationmate.utils
 
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/utils/PitestSeverity.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/utils/PitestSeverity.kt
@@ -1,0 +1,52 @@
+package com.amos.pitmutationmate.pitmutationmate.utils
+
+import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
+import com.intellij.codeInspection.ProblemHighlightType
+import com.intellij.lang.annotation.HighlightSeverity
+import com.intellij.openapi.editor.colors.CodeInsightColors
+import com.intellij.openapi.editor.colors.TextAttributesKey
+
+enum class PitestSeverity(
+    private val textAttributes: TextAttributesKey,
+    private val highlightType: ProblemHighlightType,
+    private val highlightSeverity: HighlightSeverity
+) {
+    HIGH(
+        CodeInsightColors.WARNINGS_ATTRIBUTES,
+        ProblemHighlightType.GENERIC_ERROR_OR_WARNING,
+        HighlightSeverity.WARNING
+    ),
+    MEDIUM(CodeInsightColors.WARNINGS_ATTRIBUTES, ProblemHighlightType.WEAK_WARNING, HighlightSeverity.WARNING),
+    LOW(CodeInsightColors.WARNINGS_ATTRIBUTES, ProblemHighlightType.INFORMATION, HighlightSeverity.WEAK_WARNING);
+
+    companion object {
+        fun fromMutationResults(mutationResults: List<XMLParser.MutationResult>): PitestSeverity {
+            if (mutationResults.any { it.status == "SURVIVED" }) {
+                return HIGH
+            } else if (mutationResults.any { it.status == "NO_COVERAGE" }) {
+                return MEDIUM
+            }
+            return LOW
+        }
+    }
+
+    fun defaultTextAttributes(): TextAttributesKey {
+        return textAttributes
+    }
+
+    fun highlightType(): ProblemHighlightType {
+        return highlightType
+    }
+
+    fun highlightSeverity(): HighlightSeverity {
+        return highlightSeverity
+    }
+
+    fun gutterIcon(): String {
+        return when (this) {
+            HIGH -> "dark-pink"
+            MEDIUM -> "light-pink"
+            LOW -> "light-green"
+        }
+    }
+}

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/HighlightGutterRenderer.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/HighlightGutterRenderer.kt
@@ -1,26 +1,28 @@
 // SPDX-License-Identifier: MIT
 // SPDX-FileCopyrightText: 2023 Tim Herzig <tim.herzig@hotmail.com>
 
+package com.amos.pitmutationmate.pitmutationmate.visualization
+
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.GutterIconRenderer
 import com.intellij.openapi.editor.markup.RangeHighlighter
-import com.intellij.psi.PsiElement
-import java.awt.Color
+import com.intellij.ui.JBColor
 import java.awt.Component
 import java.awt.Graphics
 import javax.swing.Icon
 
-class HighlightGutterRenderer(color: String) : GutterIconRenderer() {
-    private val toolTip = "PITest run"
-    val toolTipProvider: (PsiElement) -> String = { _ -> toolTip }
-    val color: String = color
+class HighlightGutterRenderer(val color: String) : GutterIconRenderer() {
+
     override fun equals(other: Any?): Boolean {
-        TODO("Not yet implemented")
+        if (other is HighlightGutterRenderer) {
+            return other.color == this.color
+        }
+        return false
     }
 
     override fun hashCode(): Int {
-        TODO("Not yet implemented")
+        return color.hashCode()
     }
 
     object GutterHighlighter {
@@ -37,14 +39,16 @@ class HighlightGutterRenderer(color: String) : GutterIconRenderer() {
     }
 
     override fun getIcon(): Icon {
-        return if (this.color == "light-pink") {
-            LightPinkBarIcon()
-        } else if (this.color == "dark-pink") {
-            DarkPinkBarIcon()
-        } else if (this.color == "light-green") {
-            LightGreenBarIcon()
-        } else {
-            DarkGreenBarIcon()
+        return when (this.color) {
+            "light-pink" -> {
+                LightPinkBarIcon()
+            }
+            "dark-pink" -> {
+                DarkPinkBarIcon()
+            }
+            else -> {
+                GreenBarIcon()
+            }
         }
     }
 
@@ -54,7 +58,7 @@ class HighlightGutterRenderer(color: String) : GutterIconRenderer() {
 
     private class LightPinkBarIcon : Icon {
         override fun paintIcon(c: Component?, g: Graphics, x: Int, y: Int) {
-            g.setColor(Color(252, 218, 217))
+            g.color = JBColor.PINK
             g.fillRect(x, y, iconWidth, iconHeight)
         }
 
@@ -68,7 +72,7 @@ class HighlightGutterRenderer(color: String) : GutterIconRenderer() {
     }
     private class DarkPinkBarIcon : Icon {
         override fun paintIcon(c: Component?, g: Graphics, x: Int, y: Int) {
-            g.setColor(Color(253, 161, 159))
+            g.color = JBColor.RED
             g.fillRect(x, y, iconWidth, iconHeight)
         }
 
@@ -80,23 +84,9 @@ class HighlightGutterRenderer(color: String) : GutterIconRenderer() {
             return 16
         }
     }
-    private class LightGreenBarIcon : Icon {
+    private class GreenBarIcon : Icon {
         override fun paintIcon(c: Component?, g: Graphics, x: Int, y: Int) {
-            g.setColor(Color(215, 255, 214))
-            g.fillRect(x, y, iconWidth, iconHeight)
-        }
-
-        override fun getIconWidth(): Int {
-            return 10
-        }
-
-        override fun getIconHeight(): Int {
-            return 16
-        }
-    }
-    private class DarkGreenBarIcon : Icon {
-        override fun paintIcon(c: Component?, g: Graphics, x: Int, y: Int) {
-            g.setColor(Color(161, 255, 161))
+            g.color = JBColor.GREEN
             g.fillRect(x, y, iconWidth, iconHeight)
         }
 

--- a/pitmutationmate/src/main/resources/META-INF/plugin.xml
+++ b/pitmutationmate/src/main/resources/META-INF/plugin.xml
@@ -36,10 +36,11 @@
       <runLineMarkerContributor implementationClass="com.amos.pitmutationmate.pitmutationmate.actions.GutterMarker"
                                 language=""/>
       <configurationType implementation="com.amos.pitmutationmate.pitmutationmate.configuration.RunConfigurationType"/>
+      <externalAnnotator language="" implementationClass="com.amos.pitmutationmate.pitmutationmate.editor.MutationsAnnotator"/>
   </extensions>
     <actions>
         <action id="com.amos.pitmutationmate.pitmutationmate.actions.ToolMenuAction"
-                class="com.amos.pitmutationmate.pitmutationmate.actions.ToolMenuAction" text="Run PIT MutationMate on this project"
+                class="com.amos.pitmutationmate.pitmutationmate.actions.ToolMenuAction" text="Run PIT MutationMate on This Project"
                 description="Initializes a PiTest run on the selected class">
             <add-to-group group-id="ToolsMenu" anchor="first"/>
             <!-- <keyboard-shortcut
@@ -51,10 +52,11 @@
                 keystroke="control button3 doubleClick"/> -->
         </action>
         <action id="com.amos.pitmutationmate.pitmutationmate.actions.ContextMenuAction"
-                class="com.amos.pitmutationmate.pitmutationmate.actions.ContextMenuAction" text="Run PIT MutationMate on this class"
+                class="com.amos.pitmutationmate.pitmutationmate.actions.ContextMenuAction" text="Run PIT MutationMate on This Class"
                 description="Initializes a PiTest run on the selected class">
             <add-to-group group-id="EditorPopupMenu" anchor="first"/>
             <add-to-group group-id="ProjectViewPopupMenu" anchor="first"/>
         </action>
     </actions>
+
 </idea-plugin>

--- a/pitmutationmate/src/test/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotatorGetContentOffsetTest.kt
+++ b/pitmutationmate/src/test/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotatorGetContentOffsetTest.kt
@@ -1,0 +1,56 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
+
+package com.amos.pitmutationmate.pitmutationmate.editor
+
+import com.intellij.openapi.application.runReadAction
+import com.intellij.openapi.editor.Document
+import com.intellij.openapi.vfs.VirtualFile
+import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
+import org.jetbrains.kotlin.idea.core.util.toPsiFile
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertNotNull
+
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.CsvSource
+
+class MutationsAnnotatorGetContentOffsetTest : LightJavaCodeInsightFixtureTestCase5() {
+
+    @Override
+    override fun getTestDataPath(): String {
+        return "src/test/resources"
+    }
+
+    private lateinit var virtualFile: VirtualFile
+
+    @ParameterizedTest(name = "Content offset for {0}, line {1}: Start = {2}, End = {3}")
+    @CsvSource(
+        "test_source_files/sample.kt,   3,  80, 105",
+        "test_source_files/sample.kt,   6, 170, 182",
+        "test_source_files/sample.kt,   7, 191, 226",
+        "test_source_files/sample.kt,   8, 231, 232",
+        "test_source_files/sample.java, 4, 107, 136",
+        "test_source_files/sample.java, 5, 141, 173",
+        "test_source_files/sample.java, 6, 182, 221",
+        "test_source_files/sample.java, 7, 226, 227"
+    )
+    fun `test content offset is calculated correctly`(filePath: String, lineNumber: Int, expectedStart: Int, expectedEnd: Int) {
+        virtualFile = fixture.copyFileToProject(filePath)
+        val kotlinDocument = getDocumentFromPsiFile(virtualFile)
+        val range = MutationsAnnotator.Util.getContentOffset(kotlinDocument, lineNumber)
+
+        assertNotNull(range)
+        assertEquals(expectedStart, range.startOffset)
+        assertEquals(expectedEnd, range.endOffset)
+    }
+
+    private fun getDocumentFromPsiFile(file: VirtualFile): Document {
+        return runReadAction {
+            val psiFile = file.toPsiFile(fixture.project)
+            assertNotNull(psiFile)
+            val document = fixture.getDocument(psiFile!!)
+            assertNotNull(document)
+            document
+        }
+    }
+}

--- a/pitmutationmate/src/test/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotatorGetContentOffsetTest.kt
+++ b/pitmutationmate/src/test/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotatorGetContentOffsetTest.kt
@@ -10,7 +10,6 @@ import com.intellij.testFramework.fixtures.LightJavaCodeInsightFixtureTestCase5
 import org.jetbrains.kotlin.idea.core.util.toPsiFile
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertNotNull
-
 import org.junit.jupiter.params.ParameterizedTest
 import org.junit.jupiter.params.provider.CsvSource
 

--- a/pitmutationmate/src/test/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutorTest.kt
+++ b/pitmutationmate/src/test/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutorTest.kt
@@ -12,6 +12,7 @@ import org.mockito.InjectMocks
 import org.mockito.Mock
 import org.mockito.Mockito.`when`
 import org.mockito.MockitoAnnotations
+import java.nio.file.Path
 
 /**
  * Tests for GradleTaskExecutor
@@ -39,6 +40,7 @@ class GradleTaskExecutorTest {
             "clean",
             "/path/to/project",
             "com.example.Class",
+            Path.of("/path/to/report"),
             8080
         )
 
@@ -56,6 +58,7 @@ class GradleTaskExecutorTest {
             "clean",
             "/path/to/project",
             "com.example.Class",
+            Path.of("/path/to/report"),
             8080
         )
 
@@ -73,6 +76,7 @@ class GradleTaskExecutorTest {
             null,
             "/path/to/project",
             "com.example.Class",
+            Path.of("/path/to/report"),
             8080
         )
 
@@ -89,6 +93,7 @@ class GradleTaskExecutorTest {
             taskName,
             "/path/to/project",
             "com.example.Class",
+            Path.of("/path/to/report"),
             8080
         )
 
@@ -104,6 +109,7 @@ class GradleTaskExecutorTest {
             "clean",
             "/path/to/project",
             null,
+            Path.of("/path/to/report"),
             8080
         )
 
@@ -122,6 +128,7 @@ class GradleTaskExecutorTest {
             "clean",
             "/path/to/project",
             classFQN,
+            Path.of("/path/to/report"),
             8080
         )
 

--- a/pitmutationmate/src/test/resources/test_source_files/sample.java
+++ b/pitmutationmate/src/test/resources/test_source_files/sample.java
@@ -1,0 +1,7 @@
+package test_source_files;
+
+public class SampleJavaFile {
+    public static void helloJava() {
+        System.out.println("Hello from Java!");
+    }
+}

--- a/pitmutationmate/src/test/resources/test_source_files/sample.java
+++ b/pitmutationmate/src/test/resources/test_source_files/sample.java
@@ -1,5 +1,7 @@
-package test_source_files;
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
 
+package test_source_files;
 public class SampleJavaFile {
     public static void helloJava() {
         System.out.println("Hello from Java!");

--- a/pitmutationmate/src/test/resources/test_source_files/sample.kt
+++ b/pitmutationmate/src/test/resources/test_source_files/sample.kt
@@ -1,0 +1,8 @@
+package test_source_files
+
+fun helloKotlin(x: Int) {
+    println("Hello from Kotlin!")
+    if (x > 0) {
+        println("Hello from Kotlin again!")
+    }
+}

--- a/pitmutationmate/src/test/resources/test_source_files/sample.kt
+++ b/pitmutationmate/src/test/resources/test_source_files/sample.kt
@@ -1,5 +1,7 @@
-package test_source_files
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
 
+package test_source_files
 fun helloKotlin(x: Int) {
     println("Hello from Kotlin!")
     if (x > 0) {


### PR DESCRIPTION
Added benefit: the annotator can
- add a gutter icon (red/green)
- highlight a line (when mutation survives)
- add a hover tooltip into the existing hover view

Additionally I refactored a bit so that we have less places where the parser is explicitly called.