### PR TITLE
Feature/122 adjust visualization for multiple classes

### DIFF
--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -25,12 +25,12 @@ internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
 //            ContentFactory.getInstance().createContent(LatestPiTestReport(lastCoverageReport), "Latest Result", false)
 //        }
         val coverageReport = ContentFactory.getInstance().createContent(PiTestReports(), "Reports", false)
-        val options = ContentFactory.getInstance().createContent(ResultSwitchAction(), "Options", false)
+//        val options = ContentFactory.getInstance().createContent(ResultSwitchAction(), "Options", false)
         val table = ContentFactory.getInstance().createContent(JTreeTable(), "Mutationtest Coverage", false)
         val lineChart = ContentFactory.getInstance().createContent(LineGraph(), "Line Chart", false)
         val barChart = ContentFactory.getInstance().createContent(BarGraph(), "Bar Chart", false)
 
-        toolWindow.contentManager.addContent(options)
+//        toolWindow.contentManager.addContent(options)
 //        toolWindow.contentManager.addContent(latestPiTestReport)
         toolWindow.contentManager.addContent(coverageReport)
         toolWindow.contentManager.addContent(table)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -2,7 +2,6 @@
 // SPDX-FileCopyrightText: 2023
 package com.amos.pitmutationmate.pitmutationmate
 
-import com.amos.pitmutationmate.pitmutationmate.actions.ResultSwitchAction
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
 import com.amos.pitmutationmate.pitmutationmate.visualization.*
 import com.amos.pitmutationmate.pitmutationmate.visualization.treetable.JTreeTable

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -2,10 +2,9 @@
 // SPDX-FileCopyrightText: 2023
 package com.amos.pitmutationmate.pitmutationmate
 
+import com.amos.pitmutationmate.pitmutationmate.actions.ResultSwitchAction
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
-import com.amos.pitmutationmate.pitmutationmate.visualization.BarGraph
-import com.amos.pitmutationmate.pitmutationmate.visualization.LatestPiTestReport
-import com.amos.pitmutationmate.pitmutationmate.visualization.LineGraph
+import com.amos.pitmutationmate.pitmutationmate.visualization.*
 import com.amos.pitmutationmate.pitmutationmate.visualization.treetable.JTreeTable
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -18,24 +17,44 @@ import javax.swing.JPanel
 internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         // TODO: fetch most recent results to display (e.g. when opening up the editor and previous Pitest runs are saved)
-        val lastCoverageReport: XMLParser.CoverageReport? = null
-        val latestPiTestReport = if (lastCoverageReport == null) {
-            ContentFactory.getInstance().createContent(displayErrorMessage(), "Latest Result", false)
-        } else {
-            ContentFactory.getInstance().createContent(LatestPiTestReport(lastCoverageReport), "Latest Result", false)
-        }
+
+//        val lastCoverageReport: XMLParser.CoverageReport? = null
+//        val latestPiTestReport = if (lastCoverageReport == null) {
+//            ContentFactory.getInstance().createContent(displayErrorMessage(), "Latest Result", false)
+//        } else {
+//            ContentFactory.getInstance().createContent(LatestPiTestReport(lastCoverageReport), "Latest Result", false)
+//        }
+        val coverageReport = ContentFactory.getInstance().createContent(PiTestReports(), "Reports", false)
+        val options = ContentFactory.getInstance().createContent(ResultSwitchAction(), "Options", false)
         val table = ContentFactory.getInstance().createContent(JTreeTable(), "Mutationtest Coverage", false)
         val lineChart = ContentFactory.getInstance().createContent(LineGraph(), "Line Chart", false)
         val barChart = ContentFactory.getInstance().createContent(BarGraph(), "Bar Chart", false)
 
-        toolWindow.contentManager.addContent(latestPiTestReport)
+        toolWindow.contentManager.addContent(options)
+//        toolWindow.contentManager.addContent(latestPiTestReport)
+        toolWindow.contentManager.addContent(coverageReport)
         toolWindow.contentManager.addContent(table)
         toolWindow.contentManager.addContent(lineChart)
         toolWindow.contentManager.addContent(barChart)
+
+        updateReport(toolWindow, null)
     }
 
-    fun updateReport(toolWindow: ToolWindow, newCoverageReport: XMLParser.CoverageReport) {
-        toolWindow.contentManager.findContent("Latest Result").component = LatestPiTestReport(newCoverageReport)
+    fun updateReport(toolWindow: ToolWindow, newCoverageReport: XMLParser.CoverageReport?) {
+//        toolWindow.contentManager.findContent("Latest Result").component = LatestPiTestReport(newCoverageReport)
+        val report = if (newCoverageReport != null) {
+            PiTestClassReport(newCoverageReport)
+        } else {
+            null
+        }
+        val reportWindow = toolWindow.contentManager.findContent("Reports").component
+
+        if (reportWindow is PiTestReports) {
+            if (report != null) {
+                reportWindow.addReport(report)
+            }
+            reportWindow.visualizeReports()
+        }
     }
 
     private fun displayErrorMessage(): JPanel {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -5,6 +5,7 @@ package com.amos.pitmutationmate.pitmutationmate
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
 import com.amos.pitmutationmate.pitmutationmate.visualization.BarGraph
 import com.amos.pitmutationmate.pitmutationmate.visualization.LineGraph
+import com.amos.pitmutationmate.pitmutationmate.visualization.PiTestClassReport
 import com.amos.pitmutationmate.pitmutationmate.visualization.PiTestReports
 import com.amos.pitmutationmate.pitmutationmate.visualization.treetable.JTreeTable
 import com.intellij.openapi.project.DumbAware

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -9,28 +9,17 @@ import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.wm.ToolWindow
 import com.intellij.openapi.wm.ToolWindowFactory
-import com.intellij.ui.components.JBLabel
 import com.intellij.ui.content.ContentFactory
-import javax.swing.JPanel
 
 internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
     override fun createToolWindowContent(project: Project, toolWindow: ToolWindow) {
         // TODO: fetch most recent results to display (e.g. when opening up the editor and previous Pitest runs are saved)
 
-//        val lastCoverageReport: XMLParser.CoverageReport? = null
-//        val latestPiTestReport = if (lastCoverageReport == null) {
-//            ContentFactory.getInstance().createContent(displayErrorMessage(), "Latest Result", false)
-//        } else {
-//            ContentFactory.getInstance().createContent(LatestPiTestReport(lastCoverageReport), "Latest Result", false)
-//        }
         val coverageReport = ContentFactory.getInstance().createContent(PiTestReports(), "Reports", false)
-//        val options = ContentFactory.getInstance().createContent(ResultSwitchAction(), "Options", false)
         val table = ContentFactory.getInstance().createContent(JTreeTable(), "Mutationtest Coverage", false)
         val lineChart = ContentFactory.getInstance().createContent(LineGraph(), "Line Chart", false)
         val barChart = ContentFactory.getInstance().createContent(BarGraph(), "Bar Chart", false)
 
-//        toolWindow.contentManager.addContent(options)
-//        toolWindow.contentManager.addContent(latestPiTestReport)
         toolWindow.contentManager.addContent(coverageReport)
         toolWindow.contentManager.addContent(table)
         toolWindow.contentManager.addContent(lineChart)
@@ -40,7 +29,6 @@ internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
     }
 
     fun updateReport(toolWindow: ToolWindow, newCoverageReport: XMLParser.CoverageReport?) {
-//        toolWindow.contentManager.findContent("Latest Result").component = LatestPiTestReport(newCoverageReport)
         val report = if (newCoverageReport != null) {
             PiTestClassReport(newCoverageReport)
         } else {
@@ -54,16 +42,5 @@ internal class MutationTestToolWindowFactory : ToolWindowFactory, DumbAware {
             }
             reportWindow.visualizeReports()
         }
-    }
-
-    private fun displayErrorMessage(): JPanel {
-        val panel = JPanel()
-
-        // Displaying an error message in the panel
-        val errorMessage = "No results to display yet."
-        val errorLabel = JBLabel(errorMessage)
-        panel.add(errorLabel)
-
-        return panel
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/MutationTestToolWindowFactory.kt
@@ -3,7 +3,9 @@
 package com.amos.pitmutationmate.pitmutationmate
 
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
-import com.amos.pitmutationmate.pitmutationmate.visualization.*
+import com.amos.pitmutationmate.pitmutationmate.visualization.BarGraph
+import com.amos.pitmutationmate.pitmutationmate.visualization.LineGraph
+import com.amos.pitmutationmate.pitmutationmate.visualization.PiTestReports
 import com.amos.pitmutationmate.pitmutationmate.visualization.treetable.JTreeTable
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -53,7 +53,8 @@ abstract class RunConfigurationAction : AnAction() {
             mutationCoveragePercentage = 50,
             mutationCoverageTextRatio = "100/200",
             testStrengthPercentage = 40,
-            testStrengthTextRatio = "80/200"
+            testStrengthTextRatio = "80/200",
+            numberOfClasses = 1
         )
         if (toolWindow != null) {
             mutationTestToolWindowFactorySingleton.updateReport(toolWindow, coverageReport)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLParser.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/reporting/XMLParser.kt
@@ -136,6 +136,7 @@ class XMLParser {
         val mutationCoveragePercentage: Int,
         val mutationCoverageTextRatio: String,
         val testStrengthPercentage: Int,
-        val testStrengthTextRatio: String
+        val testStrengthTextRatio: String,
+        val numberOfClasses: Int
     )
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/LatestPiTestReport.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/LatestPiTestReport.kt
@@ -26,7 +26,8 @@ class LatestPiTestReport(
         mutationCoveragePercentage = 0,
         mutationCoverageTextRatio = "",
         testStrengthPercentage = 0,
-        testStrengthTextRatio = ""
+        testStrengthTextRatio = "",
+        numberOfClasses = 0
     )
 ) : JPanel() {
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
@@ -20,6 +20,66 @@ import javax.swing.ListSelectionModel
 import javax.swing.table.DefaultTableCellRenderer
 import javax.swing.table.DefaultTableModel
 
+private class cellRenderer : DefaultTableCellRenderer() {
+
+    override fun getTableCellRendererComponent(
+        table: JTable?,
+        value: Any?,
+        isSelected: Boolean,
+        hasFocus: Boolean,
+        row: Int,
+        column: Int
+    ): Component {
+        if (value is PiTestClassReport) {
+            return value
+        } else if (value is CustomProgressBar) {
+            return value
+        } else if (value is JBLabel) {
+            return value
+        } else {
+            return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+        }
+    }
+}
+
+fun createTable(data: Array<Array<out JComponent>>, columnNames: Array<String>): JBTable {
+    val model = object : DefaultTableModel(data, columnNames) {
+        override fun isCellEditable(row: Int, column: Int): Boolean {
+            return false
+        }
+    }
+
+    val table = JBTable(model)
+
+//    table.setRowHeight(lineCoverageBar.height + 2)
+    table.tableHeader.reorderingAllowed = false
+    table.tableHeader.resizingAllowed = false
+    table.tableHeader.font = UIUtil.getLabelFont()
+
+    table.border = JBUI.Borders.empty()
+    table.setShowGrid(false)
+    table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+    table.columnSelectionAllowed = false
+    table.intercellSpacing = Dimension(0, 0)
+
+    val firstColumnWidth = table.tableHeader.getFontMetrics(table.tableHeader.font).stringWidth(" Pit Test Coverage Report ") + 5
+    table.columnModel.getColumn(0).maxWidth = firstColumnWidth
+    table.columnModel.getColumn(0).minWidth = firstColumnWidth
+    table.columnModel.getColumn(0).preferredWidth = firstColumnWidth
+    table.columnModel.getColumn(0).width = firstColumnWidth
+
+    table.columnModel.getColumn(0).cellRenderer = cellRenderer()
+    table.columnModel.getColumn(1).cellRenderer = cellRenderer()
+
+    return table
+}
+
+fun getLabel(text: String): JBLabel {
+    val label = JBLabel(text)
+    label.font = UIUtil.getLabelFont()
+    return label
+}
+
 class PiTestClassReport(
     private val coverageReport: XMLParser.CoverageReport = XMLParser.CoverageReport(
         lineCoveragePercentage = 0,
@@ -33,96 +93,28 @@ class PiTestClassReport(
 
     private var height: Int = 0
 
-    fun largeRenderer() {
+    fun renderer(compact: Boolean = false) {
         this.removeAll() // To assure an empty block
         val lineCoverageBar = CustomProgressBar(this.coverageReport.lineCoveragePercentage, this.coverageReport.lineCoverageTextRatio)
         val mutationCoverageBar = CustomProgressBar(this.coverageReport.mutationCoveragePercentage, this.coverageReport.mutationCoverageTextRatio)
         val testStrengthBar = CustomProgressBar(this.coverageReport.testStrengthPercentage, this.coverageReport.testStrengthTextRatio)
 
-        val data = arrayOf(
-            arrayOf(getLabel("Class Name"), getLabel("Test.java")),
-            arrayOf(getLabel("Line Coverage"), lineCoverageBar),
-            arrayOf(getLabel("Mutation Coverage"), mutationCoverageBar),
-            arrayOf(getLabel("Test Strength"), testStrengthBar)
-        )
-
+        val data = if (!compact) {
+            arrayOf(
+                arrayOf(getLabel("Class Name"), getLabel("Test.java")),
+                arrayOf(getLabel("Line Coverage"), lineCoverageBar),
+                arrayOf(getLabel("Mutation Coverage"), mutationCoverageBar),
+                arrayOf(getLabel("Test Strength"), testStrengthBar)
+            )
+        } else {
+            arrayOf(
+                arrayOf(getLabel("Class Name"), getLabel("Test.java")),
+                arrayOf(getLabel("Line Coverage"), lineCoverageBar)
+            )
+        }
         val columnNames = arrayOf("Pit Test Coverage Report", "")
 
-        val model = object : DefaultTableModel(data, columnNames) {
-            override fun isCellEditable(row: Int, column: Int): Boolean {
-                return false
-            }
-        }
-
-        val table = JBTable(model)
-
-        table.setRowHeight(lineCoverageBar.height + 2)
-        table.tableHeader.reorderingAllowed = false
-        table.tableHeader.resizingAllowed = false
-        table.tableHeader.font = UIUtil.getLabelFont()
-
-        table.border = JBUI.Borders.empty()
-        table.setShowGrid(false)
-        table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
-        table.columnSelectionAllowed = false
-        table.intercellSpacing = Dimension(0, 0)
-
-        table.columnModel.getColumn(0).cellRenderer = CustomProgressBarRenderer()
-
-        val firstColumnWidth = table.tableHeader.getFontMetrics(table.tableHeader.font).stringWidth(" Pit Test Coverage Report ") + 5
-        table.columnModel.getColumn(0).maxWidth = firstColumnWidth
-        table.columnModel.getColumn(0).minWidth = firstColumnWidth
-        table.columnModel.getColumn(0).preferredWidth = firstColumnWidth
-        table.columnModel.getColumn(0).width = firstColumnWidth
-
-        table.columnModel.getColumn(1).cellRenderer = CustomProgressBarRenderer()
-
-        layout = BorderLayout()
-
-        add(JBScrollPane(table))
-        this.height = (table.rowCount + 2) * table.rowHeight
-    }
-
-    fun smallRenderer() {
-        this.removeAll() // To assure an empty block
-        val lineCoverageBar = CustomProgressBar(this.coverageReport.lineCoveragePercentage, this.coverageReport.lineCoverageTextRatio)
-
-        val data = arrayOf(
-            arrayOf(getLabel("Class Name"), getLabel("Test.java")),
-            arrayOf(getLabel("Line Coverage"), lineCoverageBar)
-        )
-
-        val columnNames = arrayOf("Pit Test Coverage Report", "")
-
-        val model = object : DefaultTableModel(data, columnNames) {
-            override fun isCellEditable(row: Int, column: Int): Boolean {
-                return false
-            }
-        }
-
-        val table = JBTable(model)
-
-        table.setRowHeight(lineCoverageBar.height + 2)
-        table.tableHeader.reorderingAllowed = false
-        table.tableHeader.resizingAllowed = false
-        table.tableHeader.font = UIUtil.getLabelFont()
-
-        table.border = JBUI.Borders.empty()
-        table.setShowGrid(false)
-        table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
-        table.columnSelectionAllowed = false
-        table.intercellSpacing = Dimension(0, 0)
-
-        table.columnModel.getColumn(0).cellRenderer = CustomProgressBarRenderer()
-
-        val firstColumnWidth = table.tableHeader.getFontMetrics(table.tableHeader.font).stringWidth(" Pit Test Coverage Report ") + 5
-        table.columnModel.getColumn(0).maxWidth = firstColumnWidth
-        table.columnModel.getColumn(0).minWidth = firstColumnWidth
-        table.columnModel.getColumn(0).preferredWidth = firstColumnWidth
-        table.columnModel.getColumn(0).width = firstColumnWidth
-
-        table.columnModel.getColumn(1).cellRenderer = CustomProgressBarRenderer()
-
+        val table = createTable(data, columnNames)
         layout = BorderLayout()
 
         add(JBScrollPane(table))
@@ -131,32 +123,6 @@ class PiTestClassReport(
 
     fun getCustomHeight(): Int {
         return this.height
-    }
-
-    private fun getLabel(text: String): JBLabel {
-        val label = JBLabel(text)
-        label.font = UIUtil.getLabelFont()
-        return label
-    }
-
-    private class CustomProgressBarRenderer : DefaultTableCellRenderer() {
-
-        override fun getTableCellRendererComponent(
-            table: JTable?,
-            value: Any?,
-            isSelected: Boolean,
-            hasFocus: Boolean,
-            row: Int,
-            column: Int
-        ): Component {
-            if (value is CustomProgressBar) {
-                return value
-            } else if (value is JBLabel) {
-                return value
-            } else {
-                return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
-            }
-        }
     }
 }
 
@@ -178,12 +144,6 @@ class PiTestReports : JPanel() {
         return panel
     }
 
-    private fun getLabel(text: String): JBLabel {
-        val label = JBLabel(text)
-        label.font = UIUtil.getLabelFont()
-        return label
-    }
-
     fun visualizeReports() {
         this.removeAll()
         if (this.reports.isEmpty()) {
@@ -192,36 +152,21 @@ class PiTestReports : JPanel() {
         }
 
         var rows = emptyArray<Array<out JComponent>>()
-        val cols = arrayOf("Class", "Result")
+        val colNames = arrayOf("Class", "Result")
 
         var heights = emptyArray<Int>()
 
         for (i in this.reports.indices) {
             if (i < 5){
-                this.reports[i].largeRenderer()
+                this.reports[i].renderer(compact = false)
             } else {
-                this.reports[i].smallRenderer()
+                this.reports[i].renderer(compact = true)
             }
             heights += this.reports[i].getCustomHeight()
             rows += arrayOf(getLabel("Test_Report"), this.reports[i])
         }
 
-        val model = object : DefaultTableModel(rows, cols) {
-            override fun isCellEditable(row: Int, column: Int): Boolean {
-                return false
-            }
-        }
-
-        val table = JBTable(model)
-
-        table.columnModel.getColumn(0).cellRenderer = cellRenderer()
-        table.columnModel.getColumn(1).cellRenderer = cellRenderer()
-
-        val firstColumnWidth = table.tableHeader.getFontMetrics(table.tableHeader.font).stringWidth(" Pit Test Coverage Report ") + 5
-        table.columnModel.getColumn(0).maxWidth = firstColumnWidth
-        table.columnModel.getColumn(0).minWidth = firstColumnWidth
-        table.columnModel.getColumn(0).preferredWidth = firstColumnWidth
-        table.columnModel.getColumn(0).width = firstColumnWidth
+        val table = createTable(rows, colNames)
 
         for (i in heights.indices) {
             table.setRowHeight(i, heights[i])
@@ -230,25 +175,5 @@ class PiTestReports : JPanel() {
         layout = BorderLayout()
 
         add(JBScrollPane(table))
-    }
-
-    private class cellRenderer : DefaultTableCellRenderer() {
-
-        override fun getTableCellRendererComponent(
-            table: JTable?,
-            value: Any?,
-            isSelected: Boolean,
-            hasFocus: Boolean,
-            row: Int,
-            column: Int
-        ): Component {
-            if (value is PiTestClassReport) {
-                return value
-            } else if (value is JBLabel) {
-                return value
-            } else {
-                return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
-            }
-        }
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
@@ -9,9 +9,11 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
+import javaslang.Tuple
 import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Dimension
+import javax.swing.JComponent
 import javax.swing.JPanel
 import javax.swing.JTable
 import javax.swing.ListSelectionModel
@@ -29,8 +31,10 @@ class PiTestClassReport(
     )
 ) : JPanel() {
 
+    private var height: Int = 0
+
     fun largeRenderer() {
-        this.removeAll()
+        this.removeAll() // To assure an empty block
         val lineCoverageBar = CustomProgressBar(this.coverageReport.lineCoveragePercentage, this.coverageReport.lineCoverageTextRatio)
         val mutationCoverageBar = CustomProgressBar(this.coverageReport.mutationCoveragePercentage, this.coverageReport.mutationCoverageTextRatio)
         val testStrengthBar = CustomProgressBar(this.coverageReport.testStrengthPercentage, this.coverageReport.testStrengthTextRatio)
@@ -76,6 +80,57 @@ class PiTestClassReport(
         layout = BorderLayout()
 
         add(JBScrollPane(table))
+        this.height = (table.rowCount + 2) * table.rowHeight
+    }
+
+    fun smallRenderer() {
+        this.removeAll() // To assure an empty block
+        val lineCoverageBar = CustomProgressBar(this.coverageReport.lineCoveragePercentage, this.coverageReport.lineCoverageTextRatio)
+
+        val data = arrayOf(
+            arrayOf(getLabel("Class Name"), getLabel("Test.java")),
+            arrayOf(getLabel("Line Coverage"), lineCoverageBar)
+        )
+
+        val columnNames = arrayOf("Pit Test Coverage Report", "")
+
+        val model = object : DefaultTableModel(data, columnNames) {
+            override fun isCellEditable(row: Int, column: Int): Boolean {
+                return false
+            }
+        }
+
+        val table = JBTable(model)
+
+        table.setRowHeight(lineCoverageBar.height + 2)
+        table.tableHeader.reorderingAllowed = false
+        table.tableHeader.resizingAllowed = false
+        table.tableHeader.font = UIUtil.getLabelFont()
+
+        table.border = JBUI.Borders.empty()
+        table.setShowGrid(false)
+        table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+        table.columnSelectionAllowed = false
+        table.intercellSpacing = Dimension(0, 0)
+
+        table.columnModel.getColumn(0).cellRenderer = CustomProgressBarRenderer()
+
+        val firstColumnWidth = table.tableHeader.getFontMetrics(table.tableHeader.font).stringWidth(" Pit Test Coverage Report ") + 5
+        table.columnModel.getColumn(0).maxWidth = firstColumnWidth
+        table.columnModel.getColumn(0).minWidth = firstColumnWidth
+        table.columnModel.getColumn(0).preferredWidth = firstColumnWidth
+        table.columnModel.getColumn(0).width = firstColumnWidth
+
+        table.columnModel.getColumn(1).cellRenderer = CustomProgressBarRenderer()
+
+        layout = BorderLayout()
+
+        add(JBScrollPane(table))
+        this.height = (table.rowCount + 2) * table.rowHeight
+    }
+
+    fun getCustomHeight(): Int {
+        return this.height
     }
 
     private fun getLabel(text: String): JBLabel {
@@ -123,6 +178,12 @@ class PiTestReports : JPanel() {
         return panel
     }
 
+    private fun getLabel(text: String): JBLabel {
+        val label = JBLabel(text)
+        label.font = UIUtil.getLabelFont()
+        return label
+    }
+
     fun visualizeReports() {
         this.removeAll()
         if (this.reports.isEmpty()) {
@@ -130,9 +191,64 @@ class PiTestReports : JPanel() {
             return
         }
 
-        for (report in this.reports) {
-            report.largeRenderer()
-            add(report)
+        var rows = emptyArray<Array<out JComponent>>()
+        val cols = arrayOf("Class", "Result")
+
+        var heights = emptyArray<Int>()
+
+        for (i in this.reports.indices) {
+            if (i < 5){
+                this.reports[i].largeRenderer()
+            } else {
+                this.reports[i].smallRenderer()
+            }
+            heights += this.reports[i].getCustomHeight()
+            rows += arrayOf(getLabel("Test_Report"), this.reports[i])
+        }
+
+        val model = object : DefaultTableModel(rows, cols) {
+            override fun isCellEditable(row: Int, column: Int): Boolean {
+                return false
+            }
+        }
+
+        val table = JBTable(model)
+
+        table.columnModel.getColumn(0).cellRenderer = cellRenderer()
+        table.columnModel.getColumn(1).cellRenderer = cellRenderer()
+
+        val firstColumnWidth = table.tableHeader.getFontMetrics(table.tableHeader.font).stringWidth(" Pit Test Coverage Report ") + 5
+        table.columnModel.getColumn(0).maxWidth = firstColumnWidth
+        table.columnModel.getColumn(0).minWidth = firstColumnWidth
+        table.columnModel.getColumn(0).preferredWidth = firstColumnWidth
+        table.columnModel.getColumn(0).width = firstColumnWidth
+
+        for (i in heights.indices) {
+            table.setRowHeight(i, heights[i])
+        }
+
+        layout = BorderLayout()
+
+        add(JBScrollPane(table))
+    }
+
+    private class cellRenderer : DefaultTableCellRenderer() {
+
+        override fun getTableCellRendererComponent(
+            table: JTable?,
+            value: Any?,
+            isSelected: Boolean,
+            hasFocus: Boolean,
+            row: Int,
+            column: Int
+        ): Component {
+            if (value is PiTestClassReport) {
+                return value
+            } else if (value is JBLabel) {
+                return value
+            } else {
+                return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+            }
         }
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
@@ -61,7 +61,7 @@ fun createTable(data: Array<Array<out JComponent>>, columnNames: Array<String>):
     table.columnSelectionAllowed = false
     table.intercellSpacing = Dimension(0, 0)
 
-    val firstColumnWidth = table.tableHeader.getFontMetrics(table.tableHeader.font).stringWidth(" Pit Test Coverage Report ") + 5
+    val firstColumnWidth = table.tableHeader.getFontMetrics(table.tableHeader.font).stringWidth(" Pit Test Coverage Report ") + 10
     table.columnModel.getColumn(0).maxWidth = firstColumnWidth
     table.columnModel.getColumn(0).minWidth = firstColumnWidth
     table.columnModel.getColumn(0).preferredWidth = firstColumnWidth
@@ -86,7 +86,8 @@ class PiTestClassReport(
         mutationCoveragePercentage = 0,
         mutationCoverageTextRatio = "",
         testStrengthPercentage = 0,
-        testStrengthTextRatio = ""
+        testStrengthTextRatio = "",
+        numberOfClasses = 0
     )
 ) : JPanel() {
 
@@ -98,19 +99,12 @@ class PiTestClassReport(
         val mutationCoverageBar = CustomProgressBar(this.coverageReport.mutationCoveragePercentage, this.coverageReport.mutationCoverageTextRatio)
         val testStrengthBar = CustomProgressBar(this.coverageReport.testStrengthPercentage, this.coverageReport.testStrengthTextRatio)
 
-        val data = if (!compact) {
-            arrayOf(
-                arrayOf(getLabel("Class Name"), getLabel("Test.java")),
-                arrayOf(getLabel("Line Coverage"), lineCoverageBar),
-                arrayOf(getLabel("Mutation Coverage"), mutationCoverageBar),
-                arrayOf(getLabel("Test Strength"), testStrengthBar)
-            )
-        } else {
-            arrayOf(
-                arrayOf(getLabel("Class Name"), getLabel("Test.java")),
-                arrayOf(getLabel("Test Strength"), testStrengthBar)
-            )
-        }
+        val data = arrayOf(
+            arrayOf(getLabel("Number of Classes"), getLabel(this.coverageReport.numberOfClasses.toString())),
+            arrayOf(getLabel("Line Coverage"), lineCoverageBar),
+            arrayOf(getLabel("Mutation Coverage"), mutationCoverageBar),
+            arrayOf(getLabel("Test Strength"), testStrengthBar)
+        )
         val columnNames = arrayOf("Pit Test Coverage Report", "")
         val table = createTable(data, columnNames)
         layout = BorderLayout()
@@ -126,9 +120,14 @@ class PiTestClassReport(
 
 class PiTestReports : JPanel() {
     private var reports: ArrayList<PiTestClassReport> = ArrayList()
+    private var summary: PiTestClassReport = PiTestClassReport()
 
     fun addReport(report: PiTestClassReport) {
         this.reports.add(report)
+    }
+
+    fun addSummary(summary: PiTestClassReport) {
+        this.summary = summary
     }
 
     private fun displayErrorMessage(): JPanel {
@@ -155,12 +154,15 @@ class PiTestReports : JPanel() {
 
         for (i in this.reports.indices) {
             if (i < 5) {
-                this.reports[i].renderer(compact = false)
+                this.reports[i].renderer()
+                heights += this.reports[i].getCustomHeight()
+                rows += arrayOf(getLabel("Placeholder Class"), this.reports[i])
             } else {
-                this.reports[i].renderer(compact = true)
+                this.summary.renderer()
+                heights += this.summary.getCustomHeight()
+                rows += arrayOf(getLabel("Summary"), this.summary)
+                break
             }
-            heights += this.reports[i].getCustomHeight()
-            rows += arrayOf(getLabel("Placeholder Class"), this.reports[i])
         }
 
         val table = createTable(rows, colNames)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
@@ -9,7 +9,6 @@ import com.intellij.ui.components.JBScrollPane
 import com.intellij.ui.table.JBTable
 import com.intellij.util.ui.JBUI
 import com.intellij.util.ui.UIUtil
-import javaslang.Tuple
 import java.awt.BorderLayout
 import java.awt.Component
 import java.awt.Dimension
@@ -155,7 +154,7 @@ class PiTestReports : JPanel() {
         var heights = emptyArray<Int>()
 
         for (i in this.reports.indices) {
-            if (i < 5){
+            if (i < 5) {
                 this.reports[i].renderer(compact = false)
             } else {
                 this.reports[i].renderer(compact = true)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
@@ -109,11 +109,10 @@ class PiTestClassReport(
         } else {
             arrayOf(
                 arrayOf(getLabel("Class Name"), getLabel("Test.java")),
-                arrayOf(getLabel("Line Coverage"), lineCoverageBar)
+                arrayOf(getLabel("Test Strength"), testStrengthBar)
             )
         }
         val columnNames = arrayOf("Pit Test Coverage Report", "")
-
         val table = createTable(data, columnNames)
         layout = BorderLayout()
 
@@ -153,7 +152,6 @@ class PiTestReports : JPanel() {
 
         var rows = emptyArray<Array<out JComponent>>()
         val colNames = arrayOf("Class", "Result")
-
         var heights = emptyArray<Int>()
 
         for (i in this.reports.indices) {
@@ -163,7 +161,7 @@ class PiTestReports : JPanel() {
                 this.reports[i].renderer(compact = true)
             }
             heights += this.reports[i].getCustomHeight()
-            rows += arrayOf(getLabel("Test_Report"), this.reports[i])
+            rows += arrayOf(getLabel("Placeholder Class"), this.reports[i])
         }
 
         val table = createTable(rows, colNames)
@@ -173,7 +171,6 @@ class PiTestReports : JPanel() {
         }
 
         layout = BorderLayout()
-
         add(JBScrollPane(table))
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/PiTestReports.kt
@@ -1,0 +1,138 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023
+
+package com.amos.pitmutationmate.pitmutationmate.visualization
+
+import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
+import com.intellij.ui.components.JBLabel
+import com.intellij.ui.components.JBScrollPane
+import com.intellij.ui.table.JBTable
+import com.intellij.util.ui.JBUI
+import com.intellij.util.ui.UIUtil
+import java.awt.BorderLayout
+import java.awt.Component
+import java.awt.Dimension
+import javax.swing.JPanel
+import javax.swing.JTable
+import javax.swing.ListSelectionModel
+import javax.swing.table.DefaultTableCellRenderer
+import javax.swing.table.DefaultTableModel
+
+class PiTestClassReport(
+    private val coverageReport: XMLParser.CoverageReport = XMLParser.CoverageReport(
+        lineCoveragePercentage = 0,
+        lineCoverageTextRatio = "",
+        mutationCoveragePercentage = 0,
+        mutationCoverageTextRatio = "",
+        testStrengthPercentage = 0,
+        testStrengthTextRatio = ""
+    )
+) : JPanel() {
+
+    fun largeRenderer() {
+        this.removeAll()
+        val lineCoverageBar = CustomProgressBar(this.coverageReport.lineCoveragePercentage, this.coverageReport.lineCoverageTextRatio)
+        val mutationCoverageBar = CustomProgressBar(this.coverageReport.mutationCoveragePercentage, this.coverageReport.mutationCoverageTextRatio)
+        val testStrengthBar = CustomProgressBar(this.coverageReport.testStrengthPercentage, this.coverageReport.testStrengthTextRatio)
+
+        val data = arrayOf(
+            arrayOf(getLabel("Class Name"), getLabel("Test.java")),
+            arrayOf(getLabel("Line Coverage"), lineCoverageBar),
+            arrayOf(getLabel("Mutation Coverage"), mutationCoverageBar),
+            arrayOf(getLabel("Test Strength"), testStrengthBar)
+        )
+
+        val columnNames = arrayOf("Pit Test Coverage Report", "")
+
+        val model = object : DefaultTableModel(data, columnNames) {
+            override fun isCellEditable(row: Int, column: Int): Boolean {
+                return false
+            }
+        }
+
+        val table = JBTable(model)
+
+        table.setRowHeight(lineCoverageBar.height + 2)
+        table.tableHeader.reorderingAllowed = false
+        table.tableHeader.resizingAllowed = false
+        table.tableHeader.font = UIUtil.getLabelFont()
+
+        table.border = JBUI.Borders.empty()
+        table.setShowGrid(false)
+        table.setSelectionMode(ListSelectionModel.SINGLE_SELECTION)
+        table.columnSelectionAllowed = false
+        table.intercellSpacing = Dimension(0, 0)
+
+        table.columnModel.getColumn(0).cellRenderer = CustomProgressBarRenderer()
+
+        val firstColumnWidth = table.tableHeader.getFontMetrics(table.tableHeader.font).stringWidth(" Pit Test Coverage Report ") + 5
+        table.columnModel.getColumn(0).maxWidth = firstColumnWidth
+        table.columnModel.getColumn(0).minWidth = firstColumnWidth
+        table.columnModel.getColumn(0).preferredWidth = firstColumnWidth
+        table.columnModel.getColumn(0).width = firstColumnWidth
+
+        table.columnModel.getColumn(1).cellRenderer = CustomProgressBarRenderer()
+
+        layout = BorderLayout()
+
+        add(JBScrollPane(table))
+    }
+
+    private fun getLabel(text: String): JBLabel {
+        val label = JBLabel(text)
+        label.font = UIUtil.getLabelFont()
+        return label
+    }
+
+    private class CustomProgressBarRenderer : DefaultTableCellRenderer() {
+
+        override fun getTableCellRendererComponent(
+            table: JTable?,
+            value: Any?,
+            isSelected: Boolean,
+            hasFocus: Boolean,
+            row: Int,
+            column: Int
+        ): Component {
+            if (value is CustomProgressBar) {
+                return value
+            } else if (value is JBLabel) {
+                return value
+            } else {
+                return super.getTableCellRendererComponent(table, value, isSelected, hasFocus, row, column)
+            }
+        }
+    }
+}
+
+class PiTestReports : JPanel() {
+    private var reports: ArrayList<PiTestClassReport> = ArrayList()
+
+    fun addReport(report: PiTestClassReport) {
+        this.reports.add(report)
+    }
+
+    private fun displayErrorMessage(): JPanel {
+        val panel = JPanel()
+
+        // Displaying an error message in the panel
+        val errorMessage = "No results to display yet."
+        val errorLabel = JBLabel(errorMessage)
+        panel.add(errorLabel)
+
+        return panel
+    }
+
+    fun visualizeReports() {
+        this.removeAll()
+        if (this.reports.isEmpty()) {
+            this.add(displayErrorMessage())
+            return
+        }
+
+        for (report in this.reports) {
+            report.largeRenderer()
+            add(report)
+        }
+    }
+}


### PR DESCRIPTION
Multiple CoverageReports (class reports) can be displayed in the MutationTestToolWindow. When 5 results are displayed the following ones are displayed in a compact fashion. 

Currently the placeholder results are being repeated to demonstrate the behavior when multiple results are being displayed.