### PR TITLE
enabling/disabling annotations

### DIFF
--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
@@ -7,8 +7,6 @@ import com.amos.pitmutationmate.pitmutationmate.editor.PluginState
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
-import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.psi.PsiFile
 
 class AnnotationAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
@@ -17,9 +15,6 @@ class AnnotationAction : AnAction() {
         // Trigger a reanalysis of the file to refresh the annotations
         // by using the DaemonCodeAnalyzer
         val project = e.project
-        val psiFile: PsiFile? = e.getData(CommonDataKeys.PSI_FILE)
-        psiFile?.let {
-            DaemonCodeAnalyzer.getInstance(project).restart(psiFile)
-        }
+        DaemonCodeAnalyzer.getInstance(project).restart()
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
@@ -5,7 +5,6 @@ package com.amos.pitmutationmate.pitmutationmate.actions
 
 import com.amos.pitmutationmate.pitmutationmate.editor.PluginState
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
-import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
@@ -10,7 +10,7 @@ import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 
-class AnnotationAction: AnAction() {
+class AnnotationAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         PluginState.isAnnotatorEnabled = true
 
@@ -23,5 +23,4 @@ class AnnotationAction: AnAction() {
             documentManager.commitDocument(it.viewProvider.document)
         }
     }
-
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
@@ -4,23 +4,23 @@
 package com.amos.pitmutationmate.pitmutationmate.actions
 
 import com.amos.pitmutationmate.pitmutationmate.editor.PluginState
+import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
+import com.intellij.openapi.actionSystem.ActionUpdateThread
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
 import com.intellij.openapi.actionSystem.CommonDataKeys
-import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
 
 class AnnotationAction : AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
-        PluginState.isAnnotatorEnabled = true
+        PluginState.isAnnotatorEnabled = !PluginState.isAnnotatorEnabled
 
         // Trigger a reanalysis of the file to refresh the annotations
-        // by using the PsiDocumentManager to commit the changes to the document.
+        // by using the DaemonCodeAnalyzer
         val project = e.project
-        val documentManager = PsiDocumentManager.getInstance(project!!)
         val psiFile: PsiFile? = e.getData(CommonDataKeys.PSI_FILE)
         psiFile?.let {
-            documentManager.commitDocument(it.viewProvider.document)
+            DaemonCodeAnalyzer.getInstance(project).restart(psiFile)
         }
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
@@ -6,21 +6,20 @@ package com.amos.pitmutationmate.pitmutationmate.actions
 import com.amos.pitmutationmate.pitmutationmate.editor.PluginState
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.openapi.actionSystem.CommonDataKeys
 import com.intellij.psi.PsiDocumentManager
 import com.intellij.psi.PsiFile
-import com.intellij.openapi.actionSystem.CommonDataKeys
 
 class AnnotationAction: AnAction() {
     override fun actionPerformed(e: AnActionEvent) {
         PluginState.isAnnotatorEnabled = true
+
+        // Trigger a reanalysis of the file to refresh the annotations
+        // by using the PsiDocumentManager to commit the changes to the document.
         val project = e.project
         val documentManager = PsiDocumentManager.getInstance(project!!)
-
-        // Use CommonDataKeys.PSI_FILE to get the PsiFile
         val psiFile: PsiFile? = e.getData(CommonDataKeys.PSI_FILE)
-
         psiFile?.let {
-            // Get the current editor's document and commit the changes
             documentManager.commitDocument(it.viewProvider.document)
         }
     }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/AnnotationAction.kt
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Brianne Oberson
+
+package com.amos.pitmutationmate.pitmutationmate.actions
+
+import com.amos.pitmutationmate.pitmutationmate.editor.PluginState
+import com.intellij.openapi.actionSystem.AnAction
+import com.intellij.openapi.actionSystem.AnActionEvent
+import com.intellij.psi.PsiDocumentManager
+import com.intellij.psi.PsiFile
+import com.intellij.openapi.actionSystem.CommonDataKeys
+
+class AnnotationAction: AnAction() {
+    override fun actionPerformed(e: AnActionEvent) {
+        PluginState.isAnnotatorEnabled = true
+        val project = e.project
+        val documentManager = PsiDocumentManager.getInstance(project!!)
+
+        // Use CommonDataKeys.PSI_FILE to get the PsiFile
+        val psiFile: PsiFile? = e.getData(CommonDataKeys.PSI_FILE)
+
+        psiFile?.let {
+            // Get the current editor's document and commit the changes
+            documentManager.commitDocument(it.viewProvider.document)
+        }
+    }
+
+}

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -64,7 +64,5 @@ abstract class RunConfigurationAction : AnAction() {
         if (toolWindow != null) {
             mutationTestToolWindowFactorySingleton.updateReport(toolWindow, coverageReport)
         }
-
-
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -6,6 +6,7 @@ package com.amos.pitmutationmate.pitmutationmate.actions
 import com.amos.pitmutationmate.pitmutationmate.MutationTestToolWindowFactory
 import com.amos.pitmutationmate.pitmutationmate.configuration.RunConfiguration
 import com.amos.pitmutationmate.pitmutationmate.configuration.RunConfigurationType
+import com.amos.pitmutationmate.pitmutationmate.editor.PluginState
 import com.amos.pitmutationmate.pitmutationmate.reporting.XMLParser
 import com.amos.pitmutationmate.pitmutationmate.services.PluginCheckerService
 import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
@@ -40,6 +41,7 @@ abstract class RunConfigurationAction : AnAction() {
         ProgramRunnerUtil.executeConfiguration(runConfig, executor!!)
 
         // restart code highlighting upon new pitest results
+        PluginState.isAnnotatorEnabled = true
         // TODO: ensure only the external annotator is rerun
         DaemonCodeAnalyzer.getInstance(project).restart()
 
@@ -62,5 +64,7 @@ abstract class RunConfigurationAction : AnAction() {
         if (toolWindow != null) {
             mutationTestToolWindowFactorySingleton.updateReport(toolWindow, coverageReport)
         }
+
+
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotator.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/MutationsAnnotator.kt
@@ -60,7 +60,10 @@ class MutationsAnnotator :
         private val log = Logger.getInstance(MutationsAnnotator::class.java)
     }
 
-    override fun collectInformation(file: PsiFile): List<XMLParser.MutationResult> {
+    override fun collectInformation(file: PsiFile): List<XMLParser.MutationResult>? {
+        if (!PluginState.isAnnotatorEnabled) {
+            return null
+        }
         log.debug("collectInformation")
         val resultGenerator = file.project.service<MutationResultService>()
         return resultGenerator.getMutationResult().mutationResults.filter { it.sourceFile == file.name }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/PluginState.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/editor/PluginState.kt
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2023 Brianne Oberson
+
+package com.amos.pitmutationmate.pitmutationmate.editor
+
+object PluginState {
+    var isAnnotatorEnabled: Boolean = false
+}

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/HighlightGutterRenderer.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/HighlightGutterRenderer.kt
@@ -3,6 +3,8 @@
 
 package com.amos.pitmutationmate.pitmutationmate.visualization
 
+import com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction
+import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.editor.Editor
 import com.intellij.openapi.editor.colors.TextAttributesKey
 import com.intellij.openapi.editor.markup.GutterIconRenderer
@@ -52,6 +54,9 @@ class HighlightGutterRenderer(val color: String) : GutterIconRenderer() {
         }
     }
 
+    override fun getClickAction(): AnAction {
+        return AnnotationAction()
+    }
     override fun getAlignment(): Alignment {
         return Alignment.LEFT
     }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/HighlightGutterRenderer.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/HighlightGutterRenderer.kt
@@ -57,6 +57,11 @@ class HighlightGutterRenderer(val color: String) : GutterIconRenderer() {
     override fun getClickAction(): AnAction {
         return AnnotationAction()
     }
+
+    override fun getTooltipText(): String {
+        return "Click to disable MutationMate annotations"
+    }
+
     override fun getAlignment(): Alignment {
         return Alignment.LEFT
     }

--- a/pitmutationmate/src/main/resources/META-INF/plugin.xml
+++ b/pitmutationmate/src/main/resources/META-INF/plugin.xml
@@ -61,16 +61,16 @@
                 keymap="$default"
                 keystroke="control button3 doubleClick"/> -->
         </action>
+        <action id="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
+                class="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
+                text="Enable MutationMate Annotations" description="Shows MutationMate editor annotations">
+            <add-to-group group-id="EditorPopupMenu" anchor="first"/>
+        </action>
         <action id="com.amos.pitmutationmate.pitmutationmate.actions.ContextMenuAction"
-                class="com.amos.pitmutationmate.pitmutationmate.actions.ContextMenuAction" text="Run PIT MutationMate on This Class"
+                class="com.amos.pitmutationmate.pitmutationmate.actions.ContextMenuAction" text="Run MutationMate on This Class"
                 description="Initializes a PiTest run on the selected class">
             <add-to-group group-id="EditorPopupMenu" anchor="first"/>
             <add-to-group group-id="ProjectViewPopupMenu" anchor="first"/>
-        </action>
-        <action id="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
-                class="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
-                text="Enable MutationMate Annotations" description="Show MutationMate editor annotations">
-            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
         </action>
     </actions>
 

--- a/pitmutationmate/src/main/resources/META-INF/plugin.xml
+++ b/pitmutationmate/src/main/resources/META-INF/plugin.xml
@@ -63,7 +63,7 @@
         </action>
         <action id="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
                 class="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
-                text="Enable MutationMate Annotations" description="Shows MutationMate editor annotations">
+                text="Enable/Disable MutationMate Annotations" description="Shows MutationMate editor annotations">
             <add-to-group group-id="EditorPopupMenu" anchor="first"/>
         </action>
         <action id="com.amos.pitmutationmate.pitmutationmate.actions.ContextMenuAction"

--- a/pitmutationmate/src/main/resources/META-INF/plugin.xml
+++ b/pitmutationmate/src/main/resources/META-INF/plugin.xml
@@ -67,6 +67,11 @@
             <add-to-group group-id="EditorPopupMenu" anchor="first"/>
             <add-to-group group-id="ProjectViewPopupMenu" anchor="first"/>
         </action>
+        <action id="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
+                class="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
+                text="Enable MutationMate Annotations" description="Show MutationMate editor annotations">
+            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
+        </action>
     </actions>
 
 </idea-plugin>

--- a/pitmutationmate/src/main/resources/META-INF/plugin.xml
+++ b/pitmutationmate/src/main/resources/META-INF/plugin.xml
@@ -72,11 +72,6 @@
             <add-to-group group-id="EditorPopupMenu" anchor="first"/>
             <add-to-group group-id="ProjectViewPopupMenu" anchor="first"/>
         </action>
-        <action id="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
-                class="com.amos.pitmutationmate.pitmutationmate.actions.AnnotationAction"
-                text="Enable MutationMate Annotations" description="Show MutationMate editor annotations">
-            <add-to-group group-id="EditorPopupMenu" anchor="last"/>
-        </action>
     </actions>
 
 </idea-plugin>


### PR DESCRIPTION
This PR contains the following features:
- annotations are initially disabled
- annotations are enabled after running pitest
- annotations can be enabled and disabled through the same context menu option (making a disable option only for the highlighted lines seemed overkill)
- annotations can be disabled by clicking (left-click) on the gutter markers (color bars)
- a tooltip was added to the gutter markers to tell the user this can be clicked to disable annotations