### PR TITLE
Feature/172 fix dependency overwriting

### DIFF
--- a/pitmutationmate-override-plugin/plugin/build.gradle.kts
+++ b/pitmutationmate-override-plugin/plugin/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.2")
 }
 
-version = "1.0"
 group = "io.github.amos-pitmutationmate.pitmutationmate.override"
+version = "1.1"
 
 gradlePlugin {
     website = "https://github.com/amosproj/amos2023ws02-pitest-ide-plugin"

--- a/pitmutationmate-override-plugin/plugin/build.gradle.kts
+++ b/pitmutationmate-override-plugin/plugin/build.gradle.kts
@@ -31,8 +31,8 @@ dependencies {
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.2")
 }
 
-group = "io.github.amosproj"
 version = "1.0"
+group = "io.github.amos-pitmutationmate.pitmutationmate.override"
 
 gradlePlugin {
     website = "https://github.com/amosproj/amos2023ws02-pitest-ide-plugin"
@@ -40,7 +40,7 @@ gradlePlugin {
 
     plugins {
         create("pitmutationmate-partner-plugin") {
-            id = "io.github.amosproj.pitmutationmate.override"
+            id = "io.github.amos-pitmutationmate.pitmutationmate.override"
             displayName = "PITMutationMate Partner Plugin"
             description = "A plugin that lets you override the PITest settings of the gradle-pitest-plugin " +
                 "to use with the PITMutationMate  Intellij plugin."

--- a/pitmutationmate-override-plugin/plugin/build.gradle.kts
+++ b/pitmutationmate-override-plugin/plugin/build.gradle.kts
@@ -25,8 +25,8 @@ tasks.test {
 
 dependencies {
     implementation("commons-beanutils:commons-beanutils-core:1.8.3")
-    implementation("com.netflix.nebula:nebula-test:10.3.0")
 
+    testImplementation("com.netflix.nebula:nebula-test:10.3.0")
     testImplementation("org.spockframework:spock-core:2.2-groovy-3.0")
     testRuntimeOnly("org.junit.platform:junit-platform-launcher:1.9.2")
 }

--- a/pitmutationmate-override-plugin/plugin/src/main/groovy/io/github/amosproj/pitmutationmate/override/PITSettingOverridePlugin.groovy
+++ b/pitmutationmate-override-plugin/plugin/src/main/groovy/io/github/amosproj/pitmutationmate/override/PITSettingOverridePlugin.groovy
@@ -8,25 +8,25 @@ import io.github.amosproj.pitmutationmate.override.communicaiton.MessagingServic
 import io.github.amosproj.pitmutationmate.override.communicaiton.UdpMessagingService
 import io.github.amosproj.pitmutationmate.override.reader.OverrideReader
 import io.github.amosproj.pitmutationmate.override.reader.SystemPropertyOverrideReader
-import io.github.amosproj.pitmutationmate.override.strategy.GradlePitestPluginOverrideStrategy
+import io.github.amosproj.pitmutationmate.override.strategy.DependencyInclusionStrategy
 import io.github.amosproj.pitmutationmate.override.strategy.OverrideStrategy
+import io.github.amosproj.pitmutationmate.override.strategy.PitestPropertyOverrideStrategy
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
 /**
- * Partner Plugin to the PITmutationmate Plugin to allow overriding of specific PITest configuration values.
- */
+ * Partner Plugin to the PITmutationmate Plugin to allow overriding of specific PITest configuration values.*/
 class PITSettingOverridePlugin implements Plugin<Project> {
 
-    @SuppressWarnings("FieldName")
+    @SuppressWarnings('FieldName')
     private final static Logger log = Logging.getLogger(PITSettingOverridePlugin)
-    private final static String PORT_PROPERTY_NAME = "port"
+    private final static String PORT_PROPERTY_NAME = 'port'
 
     void apply(Project project) {
         OverrideReader overrideReader = new SystemPropertyOverrideReader()
-        def overrideProperties = overrideReader.parseProperties()
+        Map<String, String> overrideProperties = overrideReader.parseProperties()
         log.debug("Found override properties: $overrideProperties")
 
         MessagingService messagingService
@@ -37,21 +37,28 @@ class PITSettingOverridePlugin implements Plugin<Project> {
             log.info("Using UDP messaging service at port $port.")
             messagingService = new UdpMessagingService(port: port)
         } else {
-            log.info("No port given for the message server. Not sending messages.")
+            log.info('No port given for the message server. Not sending messages.')
         }
 
         project.gradle.projectsEvaluated {
             try {
                 overrideProperties.each { propertyName, overrideValue ->
-                    project.logger.info "Overriding property '$propertyName' with '$overrideValue'."
-                    OverrideStrategy gradlePitestPluginOverrideStrategy = new GradlePitestPluginOverrideStrategy()
-                    gradlePitestPluginOverrideStrategy.apply(project, propertyName, overrideValue)
+                    log.debug("Got property '$propertyName' with new value '$overrideValue'.")
+
+                    OverrideStrategy strategy
+                    if (propertyName == DependencyInclusionStrategy.OVERRIDE_ATTRIBUTE) {
+                        strategy = new DependencyInclusionStrategy()
+                    } else {
+                        strategy = new PitestPropertyOverrideStrategy()
+                    }
+                    strategy.apply(project, propertyName, overrideValue)
                     if (messagingService != null) {
-                        messagingService.sendMessage("Overrode property '$propertyName' with '$overrideValue'.")
+                        messagingService.sendMessage(
+                            "Property '$propertyName' with '$overrideValue' successfully overwritten.")
                     }
                 }
             } catch (Exception e) {
-                log.error("Error while overriding PITest settings.", e)
+                log.error('Error overriding PITest settings.', e)
                 if (messagingService != null) {
                     messagingService.sendMessage("Error while overriding PITest settings: ${e.message}")
                 }

--- a/pitmutationmate-override-plugin/plugin/src/main/groovy/io/github/amosproj/pitmutationmate/override/strategy/DependencyInclusionStrategy.groovy
+++ b/pitmutationmate-override-plugin/plugin/src/main/groovy/io/github/amosproj/pitmutationmate/override/strategy/DependencyInclusionStrategy.groovy
@@ -1,0 +1,81 @@
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
+//
+// SPDX-License-Identifier: MIT
+
+package io.github.amosproj.pitmutationmate.override.strategy
+
+import io.github.amosproj.pitmutationmate.override.PITSettingOverridePlugin
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.logging.Logger
+import org.gradle.api.logging.Logging
+
+/**
+ * DependencyInclusionStrategy
+ *
+ * This class is responsible for adding a dependency to the pitest plugin extension.
+ * It is used by the [PITSettingOverridePlugin].
+ *
+ * @see [ PITSettingOverridePlugin ]
+ */
+class DependencyInclusionStrategy implements OverrideStrategy {
+
+    public static final String OVERRIDE_ATTRIBUTE = 'addCoverageListenerDependency'
+    static final String PITEST_EXTENSION = 'pitest'
+    static final String PITEST_PLUGIN = 'info.solidsoft.pitest'
+    static final String PITEST_PLUGIN_ANDROID = 'pl.droidsonroids.pitest'
+
+    @SuppressWarnings('FieldName')
+    private final static Logger log = Logging.getLogger(PITSettingOverridePlugin)
+
+    @Override
+    void apply(Project proj, String propertyName, String overrideValue) {
+        log.debug("Trying to add dependency '$overrideValue'.")
+
+        boolean isApplied = false
+        proj.allprojects {
+            Project project = it
+            def pitestPlugin = getPlugin(project, PITEST_PLUGIN)
+            def androidPitestPlugin = getPlugin(project, PITEST_PLUGIN_ANDROID)
+
+            if (pitestPlugin != null) {
+                log.debug("Adding dependency for detected Pitest Plugin $PITEST_PLUGIN")
+                project.dependencies.add(PITEST_EXTENSION, overrideValue)
+                isApplied = true
+            } else if (androidPitestPlugin != null) {
+                log.debug("Adding dependency for detected Pitest Plugin $PITEST_PLUGIN_ANDROID")
+                project.subprojects {
+                    buildscript {
+                        dependencies.add(PITEST_EXTENSION, overrideValue)
+                    }
+                }
+                isApplied = true
+            } else {
+                log.info('No Pitest Plugin detected')
+                return
+            }
+            log.info("Successfully added dependency '$overrideValue' to project ${project.name}.")
+        }
+        if (!isApplied) {
+            throw new GradleException('PITest plugin not found. Please apply the PITest plugin first.')
+        }
+    }
+
+    /**
+     * Find a plugin in the project or its subprojects.
+     * @param project : The project to search in.
+     * @param pluginId : The id of the plugin to search for.
+     * @return The plugin if found, null otherwise.
+     */
+    private static Object getPlugin(Project project, String pluginId) {
+        def plugin = project.plugins.findPlugin(pluginId)
+        def projectIterator = project.subprojects.iterator()
+        def subproject
+        while (plugin == null && projectIterator.hasNext()) {
+            subproject = projectIterator.next()
+            plugin = subproject.plugins.findPlugin(pluginId)
+        }
+        return plugin
+    }
+
+}

--- a/pitmutationmate-override-plugin/plugin/src/main/groovy/io/github/amosproj/pitmutationmate/override/strategy/PitestPropertyOverrideStrategy.groovy
+++ b/pitmutationmate-override-plugin/plugin/src/main/groovy/io/github/amosproj/pitmutationmate/override/strategy/PitestPropertyOverrideStrategy.groovy
@@ -12,18 +12,17 @@ import org.gradle.api.GradleException
 import org.gradle.api.Project
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
-import org.gradle.internal.component.model.ConfigurationNotFoundException
 
 /**
- * GradlePitestPluginOverrideStrategy
+ * PitestPropertyOverrideStrategy
  *
  * This class is responsible for overriding the properties of the gradle-pitest-plugin.
  * It is used by the [PITSettingOverridePlugin] to override the values of the
  * gradle-pitest-plugin extension.
  *
- * @see [PITSettingOverridePlugin]
+ * @see [ PITSettingOverridePlugin ]
  */
-class GradlePitestPluginOverrideStrategy implements OverrideStrategy {
+class PitestPropertyOverrideStrategy implements OverrideStrategy {
 
     static final String OVERRIDE_SECTION = 'pitest'
 
@@ -34,29 +33,18 @@ class GradlePitestPluginOverrideStrategy implements OverrideStrategy {
     @Override
     void apply(Project project, String propertyName, String overrideValue) {
         log.debug("Overriding property '$propertyName' with '$overrideValue'.")
+
         def pitestExtension = project.extensions.findByName(OVERRIDE_SECTION)
-        def projIter = project.subprojects.iterator()
-        def subproject = project
-        while (pitestExtension == null && projIter.hasNext()) {
-            subproject = projIter.next()
+        def projectIterator = project.subprojects.iterator()
+        def subproject
+        while (pitestExtension == null && projectIterator.hasNext()) {
+            subproject = projectIterator.next()
             pitestExtension = subproject.extensions.findByName(OVERRIDE_SECTION)
         }
 
         if (pitestExtension == null) {
             throw new GradleException("PITest extension not found. Please apply the PITest plugin first.")
         }
-        if (propertyName == "addCoverageListenerDependency") {
-            project.gradle.allprojects {
-                try {
-                    it.dependencies.add('pitest', overrideValue)
-                } catch (ConfigurationNotFoundException e) {
-                    addPitestDependency(it, overrideValue)
-                    log.debug('Tried to add the dependency directly to project.dependencies ' + e)
-                }
-            }
-            return
-        }
-
         if (!pitestExtension.hasProperty(propertyName)) {
             throw new GradleException("Unknown property with name '$propertyName' for pitest extension.")
         }
@@ -65,7 +53,7 @@ class GradlePitestPluginOverrideStrategy implements OverrideStrategy {
         def overrideProperty = overrideFields.properties.find { it.key == propertyName }
         if (overrideProperty == null) {
             throw new GradleException(
-                "Cannot override property '$propertyName' for pitest extension: Unknown Property.")
+                    "Cannot override property '$propertyName' for pitest extension: Unknown Property.")
         }
 
         Class clazz = overrideProperty.value.getClass()
@@ -75,17 +63,4 @@ class GradlePitestPluginOverrideStrategy implements OverrideStrategy {
         log.debug("Property '$propertyName' successfully overwritten with '$newValue'.")
     }
 
-    void addPitestDependency(Project project, String overrideValue) {
-        try {
-            project.subprojects {
-                buildscript {
-                    dependencies.add('pitest', overrideValue)
-                }
-            }
-        } catch (ConfigurationNotFoundException e) {
-            log.debug('Adding the dependency to all subprojects in buildscript.dependencies failed. ' +
-                    'So the ConfigurationName "pitest" was not found.' +
-                    'Most probably this means that the pitest-plugin is not included.' + e)
-        }
-    }
 }

--- a/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/TypesPropertyIntegrationTest.groovy
+++ b/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/TypesPropertyIntegrationTest.groovy
@@ -27,7 +27,7 @@ class TypesPropertyIntegrationTest extends IntegrationSpec {
         logLevel = LogLevel.DEBUG
         fork = true
         buildFile << """
-        apply plugin: 'io.github.amosproj.pitmutationmate.override'
+        apply plugin: 'io.github.amos-pitmutationmate.pitmutationmate.override'
         """
     }
 

--- a/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/strategy/DependencyInclusionStrategyTest.groovy
+++ b/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/strategy/DependencyInclusionStrategyTest.groovy
@@ -1,0 +1,28 @@
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
+//
+// SPDX-License-Identifier: MIT
+
+package io.github.amosproj.pitmutationmate.override.strategy
+
+import nebula.test.ProjectSpec
+import org.gradle.api.GradleException
+
+/**
+ * Tests for [DependencyInclusionStrategy].
+ * Cannot test more since adding plugins does not seem to work in tests.
+ */
+class DependencyInclusionStrategyTest extends ProjectSpec {
+
+    def "Throws exception if pitest plugin cannot be resolved"() {
+        given:
+        OverrideStrategy overrideStrategy = new DependencyInclusionStrategy()
+
+        when:
+        overrideStrategy.apply(project, 'doesntExist', 'test')
+
+        then:
+        Throwable t = thrown(GradleException)
+        t.message == "PITest plugin not found. Please apply the PITest plugin first."
+    }
+
+}

--- a/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/strategy/PitestPropertyOverrideStrategyTest.groovy
+++ b/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/strategy/PitestPropertyOverrideStrategyTest.groovy
@@ -10,6 +10,7 @@
 package io.github.amosproj.pitmutationmate.override.strategy
 
 import io.github.amosproj.pitmutationmate.override.PITConfigurationValues
+import io.github.amosproj.pitmutationmate.override.utils.PitestSampleFailingExtension
 import nebula.test.ProjectSpec
 import org.gradle.api.GradleException
 import org.gradle.api.file.Directory
@@ -168,8 +169,3 @@ class PitestPropertyOverrideStrategyTest extends ProjectSpec {
 
 }
 
-class PitestSampleFailingExtension {
-
-    String doesNotExist
-
-}

--- a/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/strategy/PitestPropertyOverrideStrategyTest.groovy
+++ b/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/strategy/PitestPropertyOverrideStrategyTest.groovy
@@ -17,13 +17,13 @@ import org.gradle.api.file.Directory
 import java.nio.file.Files
 
 /**
- * Tests for [GradlePitestPluginOverrideStrategy].
+ * Tests for [PitestPropertyOverrideStrategy].
  */
-class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
+class PitestPropertyOverrideStrategyTest extends ProjectSpec {
 
     def "Throws exception if pitest extension cannot be resolved"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
 
         when:
         overrideStrategy.apply(project, 'doesntExist', 'test')
@@ -35,7 +35,7 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
    def "Throws exception if extension does not have property"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.add('pitest', new Object())
 
         when:
@@ -48,20 +48,20 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
    def "Throws exception if PITConfigurationValues does not have property"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.create('pitest', PitestSampleFailingExtension)
 
         when:
-        overrideStrategy.apply(project, 'doesntExist', 'test')
+        overrideStrategy.apply(project, 'doesNotExist', 'test')
 
         then:
         Throwable t = thrown(GradleException)
-        t.message == "Cannot override property 'doesntExist' for pitest extension: Unknown Property."
+        t.message == "Cannot override property 'doesNotExist' for pitest extension: Unknown Property."
    }
 
    def "Can override pitest property threads"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.create('pitest', PITConfigurationValues)
         assert project.pitest.threads == 4
 
@@ -74,7 +74,7 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
    def "Can override pitest property verbose"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.create('pitest', PITConfigurationValues)
         assert project.pitest.verbose == true
 
@@ -87,7 +87,7 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
    def "Can override pitest property includeLaunchClasspath"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.create('pitest', PITConfigurationValues)
         assert project.pitest.includeLaunchClasspath == true
 
@@ -100,7 +100,7 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
    def "Can override pitest property timestampedReports"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.create('pitest', PITConfigurationValues)
         assert project.pitest.timestampedReports == true
 
@@ -113,7 +113,7 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
    def "Can override pitest property targetClasses"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.create('pitest', PITConfigurationValues)
         assert project.pitest.targetClasses == [ "test1", "test2" ].toSet()
 
@@ -126,7 +126,7 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
    def "Can override pitest property targetTests"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.create('pitest', PITConfigurationValues)
         assert project.pitest.targetTests == [ "test3", "test4" ].toSet()
 
@@ -139,7 +139,7 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
    def "Can override pitest property outputFormats"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.create('pitest', PITConfigurationValues)
         assert project.pitest.outputFormats == [ "XML", "HTML" ].toSet()
 
@@ -152,7 +152,7 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
    def "Can override pitest property reportDir"() {
         given:
-        OverrideStrategy overrideStrategy = new GradlePitestPluginOverrideStrategy()
+        OverrideStrategy overrideStrategy = new PitestPropertyOverrideStrategy()
         project.extensions.create('pitest', PITConfigurationValues)
         def givenDir = new File('build/reports/pitest') as Directory
         def newDirPath = Files.createTempDirectory("myTempDirPrefix")
@@ -170,6 +170,6 @@ class GradlePitestPluginOverrideStrategyTest extends ProjectSpec {
 
 class PitestSampleFailingExtension {
 
-    String doesntExist
+    String doesNotExist
 
 }

--- a/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/utils/PitestSampleFailingExtension.groovy
+++ b/pitmutationmate-override-plugin/plugin/src/test/groovy/io/github/amosproj/pitmutationmate/override/utils/PitestSampleFailingExtension.groovy
@@ -1,0 +1,14 @@
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs
+//
+// SPDX-License-Identifier: MIT
+
+package io.github.amosproj.pitmutationmate.override.utils
+
+/**
+ * This class is used to test the plugin.
+ */
+class PitestSampleFailingExtension {
+
+    String doesNotExist
+
+}

--- a/pitmutationmate-override-plugin/settings.gradle.kts
+++ b/pitmutationmate-override-plugin/settings.gradle.kts
@@ -2,5 +2,5 @@
 //
 // SPDX-License-Identifier: MIT
 
-rootProject.name = "io.github.amosproj.pitmutationmate.override"
+rootProject.name = "io.github.amos-pitmutationmate.pitmutationmate.override"
 include("plugin")


### PR DESCRIPTION
This should now properly enable the coverage dependency.
It also increases the version number to 1.1 and changes the plugin id to be inline with the one on the gradle repository.

If one or two people are able to test this in the next few days and everything works we could maybe publish the new verison over the weekend.