### PR TITLE
Feature/156 add the scope to the run configuration

### DIFF
--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -19,16 +19,8 @@ abstract class RunConfigurationAction : AnAction() {
         val executor = ExecutorRegistry.getInstance().getExecutorById("Run")
 
         val runManager = RunManager.getInstance(project)
-        val runConfigs = runManager.getConfigurationSettingsList(
-            RunConfigurationType::class.java
-        )
 
-        val runConfig: RunnerAndConfigurationSettings = if (runConfigs.isEmpty()) {
-            // create a new default run configuration
-            runManager.createConfiguration("Pitest", RunConfigurationType::class.java)
-        } else {
-            getRunConfig(runConfigs)
-        }
+        val runConfig: RunnerAndConfigurationSettings = runManager.createConfiguration("Temp Pitest Config", RunConfigurationType::class.java)
         runConfig.configuration.let {
             val rc = it as RunConfiguration
             if (classFQN != null) {
@@ -43,9 +35,5 @@ abstract class RunConfigurationAction : AnAction() {
         // TODO: ensure only the external annotator is rerun
         DaemonCodeAnalyzer.getInstance(project).restart()
         // moved tool window update since if it's done pitest didn't run through
-    }
-
-    private fun getRunConfig(runConfigs: List<RunnerAndConfigurationSettings>): RunnerAndConfigurationSettings {
-        return runConfigs[0]
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
@@ -55,13 +55,6 @@ class RunConfiguration(
             logger.debug("MutationMateRunConfiguration: classFQN was updated to '$classFQN'.")
         }
 
-    var overwriteScope: Boolean
-        get() = options.overwriteScope
-        set(overwriteScope) {
-            options.overwriteScope = overwriteScope
-            logger.debug("MutationMateRunConfiguration: overwriteScope was updated to '$overwriteScope'.")
-        }
-
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
         return com.amos.pitmutationmate.pitmutationmate.configuration.SettingsEditor()
     }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 Lennart Heimbs
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs, Brianne Oberson
 
 package com.amos.pitmutationmate.pitmutationmate.configuration
 
@@ -53,6 +53,13 @@ class RunConfiguration(
         set(classFQN) {
             options.classFQN = classFQN
             logger.debug("MutationMateRunConfiguration: classFQN was updated to '$classFQN'.")
+        }
+
+    var overwriteScope: Boolean
+        get() = options.overwriteScope
+        set(overwriteScope) {
+            options.overwriteScope = overwriteScope
+            logger.debug("MutationMateRunConfiguration: overwriteScope was updated to '$overwriteScope'.")
         }
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 Lennart Heimbs <lennart@heimbs.me>
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs <lennart@heimbs.me>, Brianne Oberson
 
 package com.amos.pitmutationmate.pitmutationmate.configuration
 
@@ -27,4 +27,6 @@ class RunConfigurationOptions : RunConfigurationOptions() {
         set(value) {
             gradleExecutableOption.setValue(this, value)
         }
+
+    var overwriteScope: Boolean by property(false)
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
@@ -28,5 +28,4 @@ class RunConfigurationOptions : RunConfigurationOptions() {
             gradleExecutableOption.setValue(this, value)
         }
 
-    var overwriteScope: Boolean by property(false)
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// SPDX-FileCopyrightText: 2023 Lennart Heimbs <lennart@heimbs.me>
+// SPDX-FileCopyrightText: 2023 Lennart Heimbs <lennart@heimbs.me>, Brianne Oberson
 
 package com.amos.pitmutationmate.pitmutationmate.configuration
 
@@ -15,6 +15,7 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     private val myPanel: JPanel
     private val gradleTaskField: TextFieldWithHistory = TextFieldWithHistory()
     private val gradleExecutableField: TextFieldWithBrowseButton = TextFieldWithBrowseButton()
+    private val enableCheckbox: JCheckBox = JCheckBox("No Overwrite")
 
     init {
         gradleTaskField.text = "pitest"
@@ -32,6 +33,7 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     }
 
     override fun resetEditorFrom(runConfiguration: RunConfiguration) {
+        enableCheckbox.isSelected = runConfiguration.isMutationMateEnabled
         gradleTaskField.text = runConfiguration.taskName
         runConfiguration.gradleExecutable.also { gradleExecutableField.text = it ?: "" }
     }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -19,8 +19,8 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     private val myPanel: JPanel
     private val gradleTaskField: TextFieldWithHistory = TextFieldWithHistory()
     private val gradleExecutableField: TextFieldWithBrowseButton = TextFieldWithBrowseButton()
-    private val scopeField: JBTextField = JBTextField()
-    private val label = JLabel("Scope should be given as a comma-separated list (no spaces!)\nof the fully qualified names of the desired classes to test.", )
+    private val targetClasses: JBTextField = JBTextField()
+    private val label = JLabel("Target classes should be given as a comma-separated list (no spaces!)\nof the fully qualified names of the desired classes to test.", )
 
     init {
         gradleTaskField.text = "pitest"
@@ -30,26 +30,26 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
             null,
             FileChooserDescriptorFactory.createSingleFileDescriptor()
         )
-        scopeField.emptyText.setText("com.myproj.package1.classA,com.myproj.package1.classB,com.myproj.package2.classC,...")
+        targetClasses.emptyText.setText("com.myproj.package1.classA,com.myproj.package1.classB,com.myproj.package2.classC,...")
         val userFont = UIUtil.getLabelFont()
         val customFont = Font(userFont.name, userFont.style, 12)
         label.font = customFont
         myPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent("Gradle task", gradleTaskField)
             .addLabeledComponent("Gradle script", gradleExecutableField)
-            .addLabeledComponent("Scope", scopeField)
+            .addLabeledComponent("Target classes", targetClasses)
             .addLabeledComponent("", label)
             .panel
     }
 
     override fun resetEditorFrom(runConfiguration: RunConfiguration) {
-        scopeField.text = runConfiguration.classFQN
+        targetClasses.text = runConfiguration.classFQN
         gradleTaskField.text = runConfiguration.taskName
         runConfiguration.gradleExecutable.also { gradleExecutableField.text = it ?: "" }
     }
 
     override fun applyEditorTo(runConfiguration: RunConfiguration) {
-        runConfiguration.classFQN = scopeField.text
+        runConfiguration.classFQN = targetClasses.text
         runConfiguration.taskName = gradleTaskField.text
         runConfiguration.gradleExecutable = gradleExecutableField.text
     }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -7,6 +7,7 @@ import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.TextFieldWithHistory
+import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
 import javax.swing.JCheckBox
 import javax.swing.JComponent
@@ -17,6 +18,7 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     private val gradleTaskField: TextFieldWithHistory = TextFieldWithHistory()
     private val gradleExecutableField: TextFieldWithBrowseButton = TextFieldWithBrowseButton()
     private val overwriteCheckbox: JCheckBox = JCheckBox("No Overwrite")
+    private val scopeField: JBTextField = JBTextField()
 
     init {
         gradleTaskField.text = "pitest"
@@ -26,21 +28,25 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
             null,
             FileChooserDescriptorFactory.createSingleFileDescriptor()
         )
+        scopeField.getEmptyText().setText("com.myproj.package1.classA,com.myproj.package1.classB,com.myproj.package2.classC,...")
         myPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent("Overwrite behavior", overwriteCheckbox)
             .addLabeledComponent("Gradle task", gradleTaskField)
             .addLabeledComponent("Gradle script", gradleExecutableField)
+            .addLabeledComponent("Scope", scopeField)
             .panel
     }
 
     override fun resetEditorFrom(runConfiguration: RunConfiguration) {
         overwriteCheckbox.isSelected = runConfiguration.overwriteScope
+        scopeField.text = runConfiguration.classFQN
         gradleTaskField.text = runConfiguration.taskName
         runConfiguration.gradleExecutable.also { gradleExecutableField.text = it ?: "" }
     }
 
     override fun applyEditorTo(runConfiguration: RunConfiguration) {
         runConfiguration.overwriteScope = overwriteCheckbox.isSelected
+        runConfiguration.classFQN = scopeField.text
         runConfiguration.taskName = gradleTaskField.text
         runConfiguration.gradleExecutable = gradleExecutableField.text
     }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -28,7 +28,7 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
             null,
             FileChooserDescriptorFactory.createSingleFileDescriptor()
         )
-        scopeField.getEmptyText().setText("com.myproj.package1.classA,com.myproj.package1.classB,com.myproj.package2.classC,...")
+        scopeField.emptyText.setText("com.myproj.package1.classA,com.myproj.package1.classB,com.myproj.package2.classC,...")
         myPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent("Overwrite behavior", overwriteCheckbox)
             .addLabeledComponent("Gradle task", gradleTaskField)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -17,7 +17,6 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     private val myPanel: JPanel
     private val gradleTaskField: TextFieldWithHistory = TextFieldWithHistory()
     private val gradleExecutableField: TextFieldWithBrowseButton = TextFieldWithBrowseButton()
-    private val overwriteCheckbox: JCheckBox = JCheckBox("No Overwrite")
     private val scopeField: JBTextField = JBTextField()
 
     init {
@@ -30,7 +29,6 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
         )
         scopeField.emptyText.setText("com.myproj.package1.classA,com.myproj.package1.classB,com.myproj.package2.classC,...")
         myPanel = FormBuilder.createFormBuilder()
-            .addLabeledComponent("Overwrite behavior", overwriteCheckbox)
             .addLabeledComponent("Gradle task", gradleTaskField)
             .addLabeledComponent("Gradle script", gradleExecutableField)
             .addLabeledComponent("Scope", scopeField)
@@ -38,14 +36,12 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     }
 
     override fun resetEditorFrom(runConfiguration: RunConfiguration) {
-        overwriteCheckbox.isSelected = runConfiguration.overwriteScope
         scopeField.text = runConfiguration.classFQN
         gradleTaskField.text = runConfiguration.taskName
         runConfiguration.gradleExecutable.also { gradleExecutableField.text = it ?: "" }
     }
 
     override fun applyEditorTo(runConfiguration: RunConfiguration) {
-        runConfiguration.overwriteScope = overwriteCheckbox.isSelected
         runConfiguration.classFQN = scopeField.text
         runConfiguration.taskName = gradleTaskField.text
         runConfiguration.gradleExecutable = gradleExecutableField.text

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -20,7 +20,7 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     private val gradleTaskField: TextFieldWithHistory = TextFieldWithHistory()
     private val gradleExecutableField: TextFieldWithBrowseButton = TextFieldWithBrowseButton()
     private val targetClasses: JBTextField = JBTextField()
-    private val label = JLabel("Target classes should be given as a comma-separated list (no spaces!)\nof the fully qualified names of the desired classes to test.", )
+    private val label = JLabel("Target classes should be given as a comma-separated list (no spaces!)\nof the fully qualified names of the desired classes to test.")
 
     init {
         gradleTaskField.text = "pitest"

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -9,8 +9,10 @@ import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.ui.TextFieldWithHistory
 import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
-import javax.swing.JCheckBox
+import com.intellij.util.ui.UIUtil
+import java.awt.Font
 import javax.swing.JComponent
+import javax.swing.JLabel
 import javax.swing.JPanel
 
 class SettingsEditor : SettingsEditor<RunConfiguration>() {
@@ -18,6 +20,7 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     private val gradleTaskField: TextFieldWithHistory = TextFieldWithHistory()
     private val gradleExecutableField: TextFieldWithBrowseButton = TextFieldWithBrowseButton()
     private val scopeField: JBTextField = JBTextField()
+    private val label = JLabel("Scope should be given as a comma-separated list (no spaces!)\nof the fully qualified names of the desired classes to test.", )
 
     init {
         gradleTaskField.text = "pitest"
@@ -28,10 +31,14 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
             FileChooserDescriptorFactory.createSingleFileDescriptor()
         )
         scopeField.emptyText.setText("com.myproj.package1.classA,com.myproj.package1.classB,com.myproj.package2.classC,...")
+        val userFont = UIUtil.getLabelFont()
+        val customFont = Font(userFont.name, userFont.style, 12)
+        label.font = customFont
         myPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent("Gradle task", gradleTaskField)
             .addLabeledComponent("Gradle script", gradleExecutableField)
             .addLabeledComponent("Scope", scopeField)
+            .addLabeledComponent("", label)
             .panel
     }
 


### PR DESCRIPTION
This feature was implemented slightly differently to what is written in the ticket. We decided to create a temporary run config whenever pitest is run from an action (gutter or context menu). This way the "pseudo-automatic" scope selection will always make sense. 

It didn't make sense to us that a "no overwrite" checkbox exists, because that would mean if the user creates a run config manually and checks this box, then the user would probably be confused as to why clicking the gutter run button next to the class doesn't run for that class (but for their manually defined scope). 

The user can set a scope manually through the Run Configuration editor and this scope will never be overwritten.

