### PR TITLE
Feature/add package coverage info to xml file

### DIFF
--- a/coverage-reporter/build.gradle.kts
+++ b/coverage-reporter/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "io.github.amosproj"
-version = "1.0"
+version = "1.1"
 
 repositories {
     mavenCentral()

--- a/coverage-reporter/src/main/kotlin/io/github/amosproj/pitmutationmate/coverage/CoverageResultListener.kt
+++ b/coverage-reporter/src/main/kotlin/io/github/amosproj/pitmutationmate/coverage/CoverageResultListener.kt
@@ -73,7 +73,7 @@ class CoverageResultListener(
     }
 
     override fun handleMutationResult(results: ClassMutationResults?) {
-        if( results == null) {
+        if (results == null) {
             return
         }
         if (htmlListener is MutationHtmlReportListener) {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/RunArchiver.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/RunArchiver.kt
@@ -7,30 +7,26 @@ import com.amos.pitmutationmate.pitmutationmate.services.ReportPathGeneratorServ
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.Project
 import java.io.File
-import java.lang.Exception
-import java.nio.file.Paths
+import java.nio.file.Path
 
-class RunArchiver(packageName: String, project: Project) {
-    private val pn: String = packageName
+class RunArchiver(project: Project) {
+
     private val reportPathGeneratorService = project.service<ReportPathGeneratorService>()
-    private val reportDirectory: File = File(reportPathGeneratorService.getReportPath().toString())
+    private val reportDirectory = File(reportPathGeneratorService.getReportPath().toString())
 
     fun archiveRun() {
         println("Archiving $reportDirectory")
-        var archiveDirectory = Paths.get(reportPathGeneratorService.getArchivePath().toString(), this.pn).toFile()
+        var archiveDirectory = Path.of(reportPathGeneratorService.getArchivePath().toString()).toFile()
         if (!archiveDirectory.exists()) {
             val success = archiveDirectory.mkdirs()
-
             if (!success) {
                 throw Exception("error creating archive directory")
             }
-
             print("Created $archiveDirectory")
         }
 
-        val index: Int = archiveDirectory.listFiles()!!.size + 1
-
-        archiveDirectory = Paths.get(archiveDirectory.path, index.toString()).toFile()
+        val index = archiveDirectory.listFiles()!!.size + 1
+        archiveDirectory = Path.of(archiveDirectory.path, index.toString()).toFile()
         val success = archiveDirectory.mkdir()
 
         if (!success) {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/RunArchiver.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/RunArchiver.kt
@@ -35,5 +35,6 @@ class RunArchiver(project: Project) {
         if (this.reportDirectory.listFiles() == null) {
             throw Exception("The last pitest run didn't generate any report files!")
         }
+        reportDirectory.copyRecursively(archiveDirectory)
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/RunArchiver.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/RunArchiver.kt
@@ -28,19 +28,12 @@ class RunArchiver(project: Project) {
         val index = archiveDirectory.listFiles()!!.size + 1
         archiveDirectory = Path.of(archiveDirectory.path, index.toString()).toFile()
         val success = archiveDirectory.mkdir()
-
         if (!success) {
             throw Exception("error creating directory to archive history Number $index")
         }
 
-        for (file in this.reportDirectory.listFiles()!!) {
-            val destinationFile = Paths.get(archiveDirectory.path.toString(), file.name).toFile()
-            try {
-                file.copyTo(destinationFile, overwrite = true)
-                println("Report ${file.path} saved successfully")
-            } catch (e: Exception) {
-                println("ErrorDialog saving report")
-            }
+        if (this.reportDirectory.listFiles() == null) {
+            throw Exception("The last pitest run didn't generate any report files!")
         }
     }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/RunArchiver.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/RunArchiver.kt
@@ -30,7 +30,7 @@ class RunArchiver(project: Project) {
         val success = archiveDirectory.mkdir()
 
         if (!success) {
-            throw Exception("error creating archive directory")
+            throw Exception("error creating directory to archive history Number $index")
         }
 
         for (file in this.reportDirectory.listFiles()!!) {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/BasePitestExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/BasePitestExecutor.kt
@@ -52,7 +52,7 @@ abstract class BasePitestExecutor {
                 }
                 // archive the pitestrun using the runarchiver
                 if (classFQN != null) {
-                    RunArchiver(classFQN, project).archiveRun()
+                    RunArchiver(project).archiveRun()
                 }
             }
         })

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutor.kt
@@ -61,7 +61,7 @@ class GradleTaskExecutor : BasePitestExecutor() {
             parameters.add("-Dpitmutationmate.override.targetClasses=$classFQN")
         }
         parameters.add("-Dpitmutationmate.override.outputFormats=XML,report-coverage")
-        parameters.add("-Dpitmutationmate.override.addCoverageListenerDependency=io.github.amosproj:coverage-reporter:1.0")
+        parameters.add("-Dpitmutationmate.override.addCoverageListenerDependency=io.github.amosproj:coverage-reporter:1.1")
         parameters.add("-Dpitmutationmate.override.verbose=true")
         parameters.add("-Dpitmutationmate.override.port=$port")
         parameters.add("-Dpitmutationmate.override.reportDir=${reportDir.toAbsolutePath()}")

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/ui/ToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/ui/ToolWindowFactory.kt
@@ -10,6 +10,7 @@ import com.amos.pitmutationmate.pitmutationmate.visualization.ConfigurationError
 import com.amos.pitmutationmate.pitmutationmate.visualization.PiTestClassReport
 import com.amos.pitmutationmate.pitmutationmate.visualization.PiTestReports
 import com.amos.pitmutationmate.pitmutationmate.visualization.treestructure.TreeStructureTable
+import com.amos.pitmutationmate.pitmutationmate.visualization.treestructure.TreeTableModel
 import com.intellij.openapi.components.service
 import com.intellij.openapi.project.DumbAware
 import com.intellij.openapi.project.Project
@@ -57,10 +58,11 @@ internal class ToolWindowFactory : ToolWindowFactory, DumbAware {
         }
 
         fun updateReport(toolWindow: ToolWindow, newResultData: XMLParser.ResultData?) {
+            val project = toolWindow.project
             val coverageResults = newResultData?.coverageReports
             val totals = newResultData?.totalResult
-            val reportWindow = toolWindow.contentManager.findContent(PiTestReports.TITLE).component
-
+            val reportWindowContent = toolWindow.contentManager.findContent(PiTestReports.TITLE) ?: return
+            val reportWindow = reportWindowContent.component
             if (reportWindow is PiTestReports) {
                 reportWindow.deleteReports()
                 if (coverageResults != null) {
@@ -70,6 +72,14 @@ internal class ToolWindowFactory : ToolWindowFactory, DumbAware {
                 }
                 totals?.let { PiTestClassReport(it) }?.let { reportWindow.setSummary(it) }
                 reportWindow.visualizeReports()
+            }
+
+            val treeStructureContent = toolWindow.contentManager.findContent(TreeStructureTable.TITLE) ?: return
+            val treeStructure = treeStructureContent.component
+
+            if(treeStructure is TreeStructureTable) {
+                val newRootNode = treeStructure.createDataStructure(project)
+                (treeStructure.treeTable.tableModel as TreeTableModel).updateData(newRootNode)
             }
         }
     }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/ui/ToolWindowFactory.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/ui/ToolWindowFactory.kt
@@ -77,7 +77,7 @@ internal class ToolWindowFactory : ToolWindowFactory, DumbAware {
             val treeStructureContent = toolWindow.contentManager.findContent(TreeStructureTable.TITLE) ?: return
             val treeStructure = treeStructureContent.component
 
-            if(treeStructure is TreeStructureTable) {
+            if (treeStructure is TreeStructureTable) {
                 val newRootNode = treeStructure.createDataStructure(project)
                 (treeStructure.treeTable.tableModel as TreeTableModel).updateData(newRootNode)
             }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/treestructure/DataNode.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/treestructure/DataNode.kt
@@ -10,14 +10,8 @@ class DataNode(
     val lineCoverage: String,
     val mutationCoverage: String,
     val testStrength: String,
-    var children: List<DataNode>?
+    var children: MutableList<DataNode>
 ) {
-
-    init {
-        if (this.children == null) {
-            this.children = emptyList()
-        }
-    }
 
     /**
      * Node text from the JTree.

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/treestructure/TreeTableModel.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/visualization/treestructure/TreeTableModel.kt
@@ -124,9 +124,14 @@ class TreeTableModel(@JvmField var rootNode: DataNode) : TreeTableModel {
         fireTreeNode(STRUCTURE_CHANGED, source, path, childIndices, children)
     }
 
+    fun updateData(newRootNode: DataNode) {
+        rootNode = newRootNode
+        fireTreeStructureChanged(this, arrayOf<Any>(rootNode), IntArray(0), arrayOf())
+    }
+
     companion object {
-        protected var columnNames = arrayOf("Name", "Number of Classes", "Line Coverage", "Mutation Coverage", "Test Strength")
-        protected var columnTypes = arrayOf(
+        private var columnNames = arrayOf("Name", "Number of Classes", "Line Coverage", "Mutation Coverage", "Test Strength")
+        private var columnTypes = arrayOf(
             TreeTableModel::class.java,
             Integer::class.java,
             String::class.java,


### PR DESCRIPTION
I added the package-coverage-information to our xml-file. So we can display it in the package-breakdown. And after every pitest run the data in the package breakdown gets updated.