### PR TITLE
Feature/156 add scope to run config

### DIFF
--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -22,6 +22,7 @@ abstract class RunConfigurationAction : AnAction() {
         var runConfig = runManager.findConfigurationByName("Default")
         if (runConfig == null) {
             runConfig = runManager.createConfiguration("Default", RunConfigurationType::class.java)
+            (runConfig.configuration as RunConfiguration).setDefault()
         }
         runConfig.configuration.let {
             val rc = it as RunConfiguration

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -22,7 +22,7 @@ abstract class RunConfigurationAction : AnAction() {
         var runConfig = runManager.findConfigurationByName("Default")
         if (runConfig == null) {
             runConfig = runManager.createConfiguration("Default", RunConfigurationType::class.java)
-            (runConfig.configuration as RunConfiguration).setDefault()
+            (runConfig.configuration as RunConfiguration).isDefault = true
         }
         runConfig.configuration.let {
             val rc = it as RunConfiguration

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -20,13 +20,17 @@ abstract class RunConfigurationAction : AnAction() {
 
         val runManager = RunManager.getInstance(project)
 
-        val runConfig: RunnerAndConfigurationSettings = runManager.createConfiguration("Temp Pitest Config", RunConfigurationType::class.java)
+        var runConfig = runManager.findConfigurationByName("Default")
+        if (runConfig == null) {
+            runConfig = runManager.createConfiguration("Default", RunConfigurationType::class.java)
+        }
         runConfig.configuration.let {
             val rc = it as RunConfiguration
             if (classFQN != null) {
                 rc.classFQN = classFQN
             }
         }
+        runManager.addConfiguration(runConfig)
 
         ProgramRunnerUtil.executeConfiguration(runConfig, executor!!)
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/actions/RunConfigurationAction.kt
@@ -10,7 +10,6 @@ import com.intellij.codeInsight.daemon.DaemonCodeAnalyzer
 import com.intellij.execution.ExecutorRegistry
 import com.intellij.execution.ProgramRunnerUtil
 import com.intellij.execution.RunManager
-import com.intellij.execution.RunnerAndConfigurationSettings
 import com.intellij.openapi.actionSystem.AnAction
 import com.intellij.openapi.project.Project
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
@@ -20,7 +20,6 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
-import com.intellij.openapi.util.JDOMExternalizerUtil
 import org.jdom.Element
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.kotlin.idea.configuration.isMavenized
@@ -56,13 +55,6 @@ class RunConfiguration(
             options.classFQN = classFQN
             logger.debug("MutationMateRunConfiguration: classFQN was updated to '$classFQN'.")
         }
-
-    override fun writeExternal(element: Element) {
-        super.writeExternal(element)
-        JDOMExternalizerUtil.writeField(element, "TASK_NAME", taskName)
-        JDOMExternalizerUtil.writeField(element, "GRADLE_EXECUTABLE", gradleExecutable)
-        JDOMExternalizerUtil.writeField(element, "CLASS_FQN", classFQN)
-    }
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
         return com.amos.pitmutationmate.pitmutationmate.configuration.SettingsEditor()

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
@@ -29,9 +29,18 @@ class RunConfiguration(
     name: String?
 ) : RunConfigurationBase<RunConfigurationOptions?>(project, factory, name) {
     private val logger: Logger = Logger.getInstance(RunConfiguration::class.java)
+    private var isDefault = false
 
     override fun getOptions(): RunConfigurationOptions {
         return super.getOptions() as RunConfigurationOptions
+    }
+
+    fun setDefault() {
+        this.isDefault = true
+    }
+
+    fun isDefault(): Boolean {
+        return this.isDefault
     }
 
     var taskName: String?
@@ -56,7 +65,9 @@ class RunConfiguration(
         }
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
-        return com.amos.pitmutationmate.pitmutationmate.configuration.SettingsEditor()
+        val settingsEditor = com.amos.pitmutationmate.pitmutationmate.configuration.SettingsEditor()
+        settingsEditor.checkDefault(this)
+        return settingsEditor
     }
 
     override fun getState(

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
@@ -20,7 +20,6 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
-import org.jdom.Element
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.kotlin.idea.configuration.isMavenized
 

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
@@ -20,6 +20,8 @@ import com.intellij.openapi.diagnostic.Logger
 import com.intellij.openapi.options.SettingsEditor
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
+import com.intellij.openapi.util.JDOMExternalizerUtil
+import org.jdom.Element
 import org.jetbrains.annotations.NotNull
 import org.jetbrains.kotlin.idea.configuration.isMavenized
 
@@ -54,6 +56,13 @@ class RunConfiguration(
             options.classFQN = classFQN
             logger.debug("MutationMateRunConfiguration: classFQN was updated to '$classFQN'.")
         }
+
+    override fun writeExternal(element: Element) {
+        super.writeExternal(element)
+        JDOMExternalizerUtil.writeField(element, "TASK_NAME", taskName)
+        JDOMExternalizerUtil.writeField(element, "GRADLE_EXECUTABLE", gradleExecutable)
+        JDOMExternalizerUtil.writeField(element, "CLASS_FQN", classFQN)
+    }
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {
         return com.amos.pitmutationmate.pitmutationmate.configuration.SettingsEditor()

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
@@ -29,19 +29,16 @@ class RunConfiguration(
     name: String?
 ) : RunConfigurationBase<RunConfigurationOptions?>(project, factory, name) {
     private val logger: Logger = Logger.getInstance(RunConfiguration::class.java)
-    private var isDefault = false
 
     override fun getOptions(): RunConfigurationOptions {
         return super.getOptions() as RunConfigurationOptions
     }
 
-    fun setDefault() {
-        this.isDefault = true
-    }
-
-    fun isDefault(): Boolean {
-        return this.isDefault
-    }
+    var isDefault: Boolean
+        get() = options.isDefault
+        set(isDefault) {
+            options.isDefault = isDefault
+        }
 
     var taskName: String?
         get() = options.taskName

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
@@ -7,21 +7,21 @@ import com.intellij.execution.configurations.RunConfigurationOptions
 import com.intellij.openapi.components.StoredProperty
 
 class RunConfigurationOptions : RunConfigurationOptions() {
-    private var taskNameOption: StoredProperty<String?> = string("").provideDelegate(this, "gradle.task")
+    private var taskNameOption: StoredProperty<String?> = string("").provideDelegate(this, "taskName")
     var taskName: String?
         get() = taskNameOption.getValue(this)
         set(value) {
             taskNameOption.setValue(this, value)
         }
 
-    private var classFQNOption: StoredProperty<String?> = string("").provideDelegate(this, "gradle.task")
+    private var classFQNOption: StoredProperty<String?> = string("").provideDelegate(this, "classFQN")
     var classFQN: String?
         get() = classFQNOption.getValue(this)
         set(value) {
             classFQNOption.setValue(this, value)
         }
 
-    private val gradleExecutableOption: StoredProperty<String?> = string("").provideDelegate(this, "gradle.executable")
+    private val gradleExecutableOption: StoredProperty<String?> = string("").provideDelegate(this, "gradleExecutable")
     var gradleExecutable: String?
         get() = gradleExecutableOption.getValue(this)
         set(value) {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
@@ -7,6 +7,13 @@ import com.intellij.execution.configurations.RunConfigurationOptions
 import com.intellij.openapi.components.StoredProperty
 
 class RunConfigurationOptions : RunConfigurationOptions() {
+    private var isDefaultOption: StoredProperty<Boolean> = property(false).provideDelegate(this, "isDefault")
+    var isDefault: Boolean
+        get() = isDefaultOption.getValue(this)
+        set(value) {
+            isDefaultOption.setValue(this, value)
+        }
+
     private var taskNameOption: StoredProperty<String?> = string("").provideDelegate(this, "taskName")
     var taskName: String?
         get() = taskNameOption.getValue(this)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -49,6 +49,12 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
         return scopeTipMessage
     }
 
+    fun checkDefault(runConfiguration: RunConfiguration) {
+        if (runConfiguration.isDefault()) {
+            targetClasses.isEditable = false
+        }
+    }
+
     override fun resetEditorFrom(runConfiguration: RunConfiguration) {
         targetClasses.text = runConfiguration.classFQN
         gradleTaskField.text = runConfiguration.taskName

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -50,7 +50,7 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     }
 
     fun checkDefault(runConfiguration: RunConfiguration) {
-        if (runConfiguration.isDefault()) {
+        if (runConfiguration.isDefault) {
             targetClasses.isEditable = false
         }
     }


### PR DESCRIPTION
- created a "Default" run config which will be used for the actionable pitest runs 
- fixed the issue with the editing of run config settings. The editor now notices changes and they can be applied. 