### PR TITLE
Feature/182: Add android build type to settings and use pitest created folder (if exists)

### DIFF
--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
@@ -94,11 +94,11 @@ class RunConfiguration(
                 if (project.isMavenized) {
                     logger.debug("MutationMateRunConfiguration: executing maven task.")
                     val mavenTaskExecutor = MavenTaskExecutor()
-                    return mavenTaskExecutor.executeTask(project, gradleExecutable, taskName, classFQN)
+                    return mavenTaskExecutor.executeTask(project, options)
                 }
                 logger.debug("MutationMateRunConfiguration: executing gradle task.")
                 val gradleTaskExecutor = GradleTaskExecutor()
-                return gradleTaskExecutor.executeTask(project, gradleExecutable, taskName, classFQN)
+                return gradleTaskExecutor.executeTask(project, options)
             }
         }
     }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfiguration.kt
@@ -44,21 +44,30 @@ class RunConfiguration(
         get() = options.taskName
         set(taskName) {
             options.taskName = taskName
-            logger.debug("MutationMateRunConfiguration: taskName was updated to '$taskName'.")
         }
 
     var gradleExecutable: String?
         get() = options.gradleExecutable
         set(gradleExecutable) {
             options.gradleExecutable = gradleExecutable
-            logger.debug("MutationMateRunConfiguration: gradleExecutable was updated to '$gradleExecutable'.")
+        }
+
+    var buildType: String?
+        get() = options.buildType
+        set(buildType) {
+            options.buildType = buildType
+        }
+
+    var verbose: Boolean
+        get() = options.verbose
+        set(verbose) {
+            options.verbose = verbose
         }
 
     var classFQN: String?
         get() = options.classFQN
         set(classFQN) {
             options.classFQN = classFQN
-            logger.debug("MutationMateRunConfiguration: classFQN was updated to '$classFQN'.")
         }
 
     override fun getConfigurationEditor(): SettingsEditor<out RunConfiguration> {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/RunConfigurationOptions.kt
@@ -34,4 +34,18 @@ class RunConfigurationOptions : RunConfigurationOptions() {
         set(value) {
             gradleExecutableOption.setValue(this, value)
         }
+
+    private val buildTypeOption: StoredProperty<String?> = string("").provideDelegate(this, "buildType")
+    var buildType: String?
+        get() = buildTypeOption.getValue(this)
+        set(value) {
+            buildTypeOption.setValue(this, value)
+        }
+
+    private val verboseOption: StoredProperty<Boolean> = property(false).provideDelegate(this, "verbose")
+    var verbose: Boolean
+        get() = verboseOption.getValue(this)
+        set(value) {
+            verboseOption.setValue(this, value)
+        }
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -53,7 +53,7 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     }
 
     private fun getBuildTypesMessage(): JLabel {
-        val multilineText = "<html>The Android build type of which you want to use for the pitest results from.<br/>If kept empty, <c>debug</c> and <c>release</c>are tried if it is an Android project.</html>"
+        val multilineText = "<html>The Android build type of which you want to use for the pitest results from.<br/>If kept empty, <c>debug</c> and <c>release</c> are tried if it is an Android project.</html>"
         val scopeTipMessage = JLabel(multilineText)
         scopeTipMessage.font = Font(UIUtil.getLabelFont().name, UIUtil.getLabelFont().style, 12)
         return scopeTipMessage

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -53,7 +53,7 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     }
 
     private fun getBuildTypesMessage(): JLabel {
-        val multilineText = "<html>The Android build type of which you want to use for the pitest results from.<br/>If kept empty, <c>debug</c> and <c>release</c> are tried if it is an Android project.</html>"
+        val multilineText = "<html>The Android build type of which you want to use for the pitest results from.<br/>If kept empty, <c>debug</c> is tried first and last no build sub-path is used.</html>"
         val scopeTipMessage = JLabel(multilineText)
         scopeTipMessage.font = Font(UIUtil.getLabelFont().name, UIUtil.getLabelFont().style, 12)
         return scopeTipMessage

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/configuration/SettingsEditor.kt
@@ -11,6 +11,7 @@ import com.intellij.ui.components.JBTextField
 import com.intellij.util.ui.FormBuilder
 import com.intellij.util.ui.UIUtil
 import java.awt.Font
+import javax.swing.JCheckBox
 import javax.swing.JComponent
 import javax.swing.JLabel
 import javax.swing.JPanel
@@ -20,7 +21,8 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
     private val gradleTaskField: TextFieldWithHistory = TextFieldWithHistory()
     private val gradleExecutableField: TextFieldWithBrowseButton = TextFieldWithBrowseButton()
     private val targetClasses: JBTextField = JBTextField()
-    private val label = JLabel("Target classes should be given as a comma-separated list (no spaces!)\nof the fully qualified names of the desired classes to test.")
+    private val buildTypesField: JBTextField = JBTextField()
+    private val verboseCheckbox = JCheckBox("Enable Pitest verbose mode")
 
     init {
         gradleTaskField.text = "pitest"
@@ -31,19 +33,27 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
             FileChooserDescriptorFactory.createSingleFileDescriptor()
         )
         targetClasses.emptyText.setText("com.myproj.package1.classA,com.myproj.package1.classB,com.myproj.package2.classC,...")
-        val userFont = UIUtil.getLabelFont()
-        val customFont = Font(userFont.name, userFont.style, 12)
-        label.font = customFont
+        buildTypesField.emptyText.setText("<none>")
         myPanel = FormBuilder.createFormBuilder()
             .addLabeledComponent("Gradle task", gradleTaskField)
             .addLabeledComponent("Gradle script", gradleExecutableField)
+            .addLabeledComponent("Android build type", buildTypesField)
+            .addLabeledComponent("", getBuildTypesMessage())
+            .addLabeledComponent("Pitest Verbose mode", verboseCheckbox)
             .addLabeledComponent("Target classes", targetClasses)
             .addLabeledComponent("", getScopeTipMessage())
             .panel
     }
 
     private fun getScopeTipMessage(): JLabel {
-        val multilineText = "<html>The scope should be given as a comma-separated list (no spaces!) of the fully qualified names<br>of the desired classes to test.</html>"
+        val multilineText = "<html>The scope should be given as a comma-separated list (no spaces!)<br/>of the fully qualified names of the desired classes to test.</html>"
+        val scopeTipMessage = JLabel(multilineText)
+        scopeTipMessage.font = Font(UIUtil.getLabelFont().name, UIUtil.getLabelFont().style, 12)
+        return scopeTipMessage
+    }
+
+    private fun getBuildTypesMessage(): JLabel {
+        val multilineText = "<html>The Android build type of which you want to use for the pitest results from.<br/>If kept empty, <c>debug</c> and <c>release</c>are tried if it is an Android project.</html>"
         val scopeTipMessage = JLabel(multilineText)
         scopeTipMessage.font = Font(UIUtil.getLabelFont().name, UIUtil.getLabelFont().style, 12)
         return scopeTipMessage
@@ -59,12 +69,16 @@ class SettingsEditor : SettingsEditor<RunConfiguration>() {
         targetClasses.text = runConfiguration.classFQN
         gradleTaskField.text = runConfiguration.taskName
         runConfiguration.gradleExecutable.also { gradleExecutableField.text = it ?: "" }
+        buildTypesField.text = runConfiguration.buildType
+        verboseCheckbox.isSelected = runConfiguration.verbose
     }
 
     override fun applyEditorTo(runConfiguration: RunConfiguration) {
         runConfiguration.classFQN = targetClasses.text
         runConfiguration.taskName = gradleTaskField.text
         runConfiguration.gradleExecutable = gradleExecutableField.text
+        runConfiguration.buildType = buildTypesField.text
+        runConfiguration.verbose = verboseCheckbox.isSelected
     }
 
     override fun createEditor(): JComponent {

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/BasePitestExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/BasePitestExecutor.kt
@@ -3,6 +3,7 @@
 
 package com.amos.pitmutationmate.pitmutationmate.execution
 
+import com.amos.pitmutationmate.pitmutationmate.configuration.RunConfigurationOptions
 import com.amos.pitmutationmate.pitmutationmate.services.ReportPathGeneratorService
 import com.amos.pitmutationmate.pitmutationmate.services.UdpMessagingServer
 import com.intellij.execution.configurations.GeneralCommandLine
@@ -19,28 +20,25 @@ abstract class BasePitestExecutor {
 
     fun executeTask(
         project: Project,
-        executable: String?,
-        overrideTaskName: String?,
-        classFQN: String?
+        options: RunConfigurationOptions
     ): ProcessHandler {
         val messagingServer = project.service<UdpMessagingServer>()
-        messagingServer.startServer(classFQN) // Start the UDP server
+        messagingServer.startServer(options.classFQN) // Start the UDP server
 
-        val reportDir = project.service<ReportPathGeneratorService>().getReportPath()
+        val reportPathGenerator = project.service<ReportPathGeneratorService>()
+        val reportDir = reportPathGenerator.getReportPath()
 
-        val commandLine = buildCommandLine(executable, overrideTaskName, project.basePath!!, classFQN, reportDir, messagingServer.port)
+        val commandLine = buildCommandLine(options, project.basePath!!, reportDir, messagingServer.port)
         log.debug("BasePitestExecutor: executeTask: commandLine: $commandLine")
         val processHandler = createProcessHandler(commandLine)
-        processHandler.addProcessListener(ExecutionDoneProcessListener(project, classFQN))
+        processHandler.addProcessListener(ExecutionDoneProcessListener(project, options.classFQN))
         ProcessTerminatedListener.attach(processHandler)
         return processHandler
     }
 
     abstract fun buildCommandLine(
-        executable: String?,
-        overrideTaskName: String?,
+        options: RunConfigurationOptions,
         projectDir: String,
-        classFQN: String?,
         reportDir: Path,
         port: Int
     ): GeneralCommandLine

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/BasePitestExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/BasePitestExecutor.kt
@@ -26,6 +26,7 @@ abstract class BasePitestExecutor {
         messagingServer.startServer(options.classFQN) // Start the UDP server
 
         val reportPathGenerator = project.service<ReportPathGeneratorService>()
+        reportPathGenerator.setBuildType(options.buildType)
         val reportDir = reportPathGenerator.getReportPath()
 
         val commandLine = buildCommandLine(options, project.basePath!!, reportDir, messagingServer.port)

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutor.kt
@@ -3,6 +3,7 @@
 
 package com.amos.pitmutationmate.pitmutationmate.execution
 
+import com.amos.pitmutationmate.pitmutationmate.configuration.RunConfigurationOptions
 import com.intellij.execution.configurations.GeneralCommandLine
 import java.io.File
 import java.nio.file.Path
@@ -20,19 +21,17 @@ class GradleTaskExecutor : BasePitestExecutor() {
     private var systemInfoProvider: SystemInfoProvider = SystemInfo()
 
     override fun buildCommandLine(
-        executable: String?,
-        overrideTaskName: String?,
+        options: RunConfigurationOptions,
         projectDir: String,
-        classFQN: String?,
         reportDir: Path,
         port: Int
     ): GeneralCommandLine {
         val commandLine = GeneralCommandLine()
-        var gradleExecutable: String? = executable
+        var gradleExecutable: String? = options.gradleExecutable
         var taskName: String? = PITEST_TASK_NAME
 
-        if (!overrideTaskName.isNullOrEmpty()) {
-            taskName = overrideTaskName
+        if (!options.taskName.isNullOrEmpty()) {
+            taskName = options.taskName
         }
 
         if (systemInfoProvider.isWindows()) {
@@ -49,20 +48,20 @@ class GradleTaskExecutor : BasePitestExecutor() {
             commandLine.addParameters(UNIX_FIRST_PARAMETER, gradleExecutable, taskName)
         }
 
-        commandLine.addParameters(getPitestOverrideParameters(classFQN, port, reportDir))
+        commandLine.addParameters(getPitestOverrideParameters(options.classFQN, port, reportDir, options.verbose))
 
         commandLine.workDirectory = File(projectDir)
         return commandLine
     }
 
-    private fun getPitestOverrideParameters(classFQN: String?, port: Int, reportDir: Path): List<String> {
+    private fun getPitestOverrideParameters(classFQN: String?, port: Int, reportDir: Path, verbose: Boolean): List<String> {
         val parameters = mutableListOf<String>()
         if (!classFQN.isNullOrEmpty()) {
             parameters.add("-Dpitmutationmate.override.targetClasses=$classFQN")
         }
         parameters.add("-Dpitmutationmate.override.outputFormats=XML,report-coverage")
         parameters.add("-Dpitmutationmate.override.addCoverageListenerDependency=io.github.amosproj:coverage-reporter:1.1")
-        parameters.add("-Dpitmutationmate.override.verbose=true")
+        parameters.add("-Dpitmutationmate.override.verbose=$verbose")
         parameters.add("-Dpitmutationmate.override.port=$port")
         parameters.add("-Dpitmutationmate.override.reportDir=${reportDir.toAbsolutePath()}")
         return parameters

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/MavenTaskExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/MavenTaskExecutor.kt
@@ -3,6 +3,7 @@
 
 package com.amos.pitmutationmate.pitmutationmate.execution
 
+import com.amos.pitmutationmate.pitmutationmate.configuration.RunConfigurationOptions
 import com.intellij.execution.configurations.GeneralCommandLine
 import java.io.File
 import java.nio.file.Path
@@ -12,26 +13,24 @@ class MavenTaskExecutor : BasePitestExecutor() {
     private var mavenExecutable: String = "mvn"
 
     override fun buildCommandLine(
-        executable: String?,
-        overrideTaskName: String?,
+        options: RunConfigurationOptions,
         projectDir: String,
-        classFQN: String?,
         reportDir: Path,
         port: Int
     ): GeneralCommandLine {
         val commandLine = GeneralCommandLine()
 
-        if (!executable.isNullOrEmpty()) {
-            this.mavenExecutable = executable
+        if (!options.gradleExecutable.isNullOrEmpty()) {
+            this.mavenExecutable = options.gradleExecutable!!
         }
 
-        if (!overrideTaskName.isNullOrEmpty()) {
-            this.taskName = overrideTaskName
+        if (!options.taskName.isNullOrEmpty()) {
+            this.taskName = options.taskName!!
         }
 
         commandLine.exePath = mavenExecutable
         commandLine.addParameters(this.taskName)
-        commandLine.addParameters(getPitestOverrideParameters(classFQN))
+        commandLine.addParameters(getPitestOverrideParameters(options.classFQN))
 
         commandLine.workDirectory = File(projectDir)
         return commandLine

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/ReportPathGeneratorService.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/ReportPathGeneratorService.kt
@@ -15,6 +15,7 @@ import kotlin.io.path.exists
  */
 @Service(Service.Level.PROJECT)
 class ReportPathGeneratorService(private val project: Project) {
+    private var buildType: String? = null
 
     /**
      * Returns the path to the report base path.
@@ -34,7 +35,7 @@ class ReportPathGeneratorService(private val project: Project) {
      */
     fun getReportPath(): Path {
         val projectBasePath = getBasePath()
-        return Path.of("$projectBasePath/build/reports/pitest/test")
+        return Path.of("$projectBasePath/build/reports/pitest/pitmutationmate")
     }
 
     /**
@@ -46,10 +47,16 @@ class ReportPathGeneratorService(private val project: Project) {
         return Path.of("$projectBasePath/.history")
     }
 
+    /**
+     * Checks if either the given build type or the debug build type exists.
+     * @return the path to the report directory with the build type or without
+     */
     private fun checkForDebugBuiltType(): Path {
-        var path = getReportPath()
-        if (Files.exists(Path.of("$path/debug"))) {
-            path = Path.of("$path/debug")
+        val path = getReportPath()
+        if (buildType != null && Files.exists(Path.of("$path/$buildType"))) {
+            return Path.of("$path/$buildType")
+        } else if (Files.exists(Path.of("$path/debug"))) {
+            return Path.of("$path/debug")
         }
         return path
     }
@@ -72,20 +79,8 @@ class ReportPathGeneratorService(private val project: Project) {
         return Path.of("$path/coverageInformation.xml")
     }
 
-    /**
-     * Creates the report path if it does not exist yet.
-     * @return the report path
-     */
-    fun createReportPath(reportPath: Path): Path {
-        if (!reportPath.exists()) {
-            try {
-                reportPath.toFile().mkdirs()
-                log.info("Created report path: $reportPath")
-            } catch (e: Exception) {
-                log.error("Could not create report path: $reportPath")
-            }
-        }
-        return reportPath
+    fun setBuildType(buildType: String?) {
+        this.buildType = buildType
     }
 
     companion object {

--- a/pitmutationmate/src/test/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutorTest.kt
+++ b/pitmutationmate/src/test/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutorTest.kt
@@ -3,6 +3,7 @@
 
 package com.amos.pitmutationmate.pitmutationmate.execution
 
+import com.amos.pitmutationmate.pitmutationmate.configuration.RunConfigurationOptions
 import org.junit.jupiter.api.Assertions.assertEquals
 import org.junit.jupiter.api.Assertions.assertFalse
 import org.junit.jupiter.api.Assertions.assertTrue
@@ -35,11 +36,13 @@ class GradleTaskExecutorTest {
     fun `test buildCommandLine for Windows`() {
         `when`(systemInfo.isWindows()).thenReturn(true)
 
+        val options = RunConfigurationOptions()
+        options.gradleExecutable = null
+        options.taskName = "clean"
+        options.classFQN = "com.example.Class"
         val commandLine = gradleTaskExecutor.buildCommandLine(
-            null,
-            "clean",
+            options,
             "/path/to/project",
-            "com.example.Class",
             Path.of("/path/to/report"),
             8080
         )
@@ -53,11 +56,13 @@ class GradleTaskExecutorTest {
     fun `test buildCommandLine for Unix`() {
         `when`(systemInfo.isWindows()).thenReturn(false)
 
+        val options = RunConfigurationOptions()
+        options.gradleExecutable = null
+        options.taskName = "clean"
+        options.classFQN = "com.example.Class"
         val commandLine = gradleTaskExecutor.buildCommandLine(
-            null,
-            "clean",
+            options,
             "/path/to/project",
-            "com.example.Class",
             Path.of("/path/to/report"),
             8080
         )
@@ -71,11 +76,13 @@ class GradleTaskExecutorTest {
     fun `test buildCommandLine without taskName uses default taskName`() {
         `when`(systemInfo.isWindows()).thenReturn(true)
 
+        val options = RunConfigurationOptions()
+        options.gradleExecutable = null
+        options.taskName = null
+        options.classFQN = "com.example.Class"
         val commandLine = gradleTaskExecutor.buildCommandLine(
-            null,
-            null,
+            options,
             "/path/to/project",
-            "com.example.Class",
             Path.of("/path/to/report"),
             8080
         )
@@ -88,11 +95,13 @@ class GradleTaskExecutorTest {
         `when`(systemInfo.isWindows()).thenReturn(true)
 
         val taskName = "test123"
+        val options = RunConfigurationOptions()
+        options.gradleExecutable = null
+        options.taskName = taskName
+        options.classFQN = "com.example.Class"
         val commandLine = gradleTaskExecutor.buildCommandLine(
-            null,
-            taskName,
+            options,
             "/path/to/project",
-            "com.example.Class",
             Path.of("/path/to/report"),
             8080
         )
@@ -104,11 +113,13 @@ class GradleTaskExecutorTest {
     fun `test buildCommandLine without classFQDN does not add targetClass override`() {
         `when`(systemInfo.isWindows()).thenReturn(true)
 
+        val options = RunConfigurationOptions()
+        options.gradleExecutable = null
+        options.taskName = "clean"
+        options.classFQN = null
         val commandLine = gradleTaskExecutor.buildCommandLine(
-            null,
-            "clean",
+            options,
             "/path/to/project",
-            null,
             Path.of("/path/to/report"),
             8080
         )
@@ -123,11 +134,13 @@ class GradleTaskExecutorTest {
         `when`(systemInfo.isWindows()).thenReturn(true)
 
         val classFQN = "com.example.Class"
+        val options = RunConfigurationOptions()
+        options.gradleExecutable = null
+        options.taskName = "clean"
+        options.classFQN = classFQN
         val commandLine = gradleTaskExecutor.buildCommandLine(
-            null,
-            "clean",
+            options,
             "/path/to/project",
-            classFQN,
             Path.of("/path/to/report"),
             8080
         )


### PR DESCRIPTION
Also fixes settings not being able to get applied in an easy way

I'm still trying to find a way to get the info automatically but haven't found a good solution yet, so adding the config setting as a backup