### PR TITLE
Bugfix/override plugin java 11

### DIFF
--- a/coverage-reporter/build.gradle.kts
+++ b/coverage-reporter/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 }
 
 group = "io.github.amosproj"
-version = "1.1"
+version = "1.2"
 
 repositories {
     mavenCentral()
@@ -24,7 +24,7 @@ tasks.test {
 }
 
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(11)
 }
 
 java {

--- a/pitmutationmate-override-plugin/plugin/build.gradle.kts
+++ b/pitmutationmate-override-plugin/plugin/build.gradle.kts
@@ -32,7 +32,7 @@ dependencies {
 }
 
 group = "io.github.amos-pitmutationmate.pitmutationmate.override"
-version = "1.1"
+version = "1.2"
 
 gradlePlugin {
     website = "https://github.com/amosproj/amos2023ws02-pitest-ide-plugin"
@@ -53,31 +53,4 @@ gradlePlugin {
             implementationClass = "io.github.amosproj.pitmutationmate.override.PITSettingOverridePlugin"
         }
     }
-}
-
-// Add a source set for the functional test suite
-val functionalTestSourceSet =
-    sourceSets.create("functionalTest") {
-    }
-
-configurations["functionalTestImplementation"].extendsFrom(configurations["testImplementation"])
-configurations["functionalTestRuntimeOnly"].extendsFrom(configurations["testRuntimeOnly"])
-
-// Add a task to run the functional tests
-val functionalTest by tasks.registering(Test::class) {
-    testClassesDirs = functionalTestSourceSet.output.classesDirs
-    classpath = functionalTestSourceSet.runtimeClasspath
-    useJUnitPlatform()
-}
-
-gradlePlugin.testSourceSets.add(functionalTestSourceSet)
-
-tasks.named<Task>("check") {
-    // Run the functional tests as part of `check`
-    dependsOn(functionalTest)
-}
-
-tasks.named<Test>("test") {
-    // Use JUnit Jupiter for unit tests.
-    useJUnitPlatform()
 }

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutor.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/execution/GradleTaskExecutor.kt
@@ -60,7 +60,7 @@ class GradleTaskExecutor : BasePitestExecutor() {
             parameters.add("-Dpitmutationmate.override.targetClasses=$classFQN")
         }
         parameters.add("-Dpitmutationmate.override.outputFormats=XML,report-coverage")
-        parameters.add("-Dpitmutationmate.override.addCoverageListenerDependency=io.github.amosproj:coverage-reporter:1.1")
+        parameters.add("-Dpitmutationmate.override.addCoverageListenerDependency=io.github.amosproj:coverage-reporter:1.2")
         parameters.add("-Dpitmutationmate.override.verbose=$verbose")
         parameters.add("-Dpitmutationmate.override.port=$port")
         parameters.add("-Dpitmutationmate.override.reportDir=${reportDir.toAbsolutePath()}")

--- a/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/PluginCheckerService.kt
+++ b/pitmutationmate/src/main/kotlin/com/amos/pitmutationmate/pitmutationmate/services/PluginCheckerService.kt
@@ -178,11 +178,11 @@ class PluginCheckerService(private val project: Project) {
 
         private const val KOTLIN_PITEST_PLUGIN = "id(\"info.solidsoft.pitest\") version \"x.y.z\""
         private const val KOTLIN_OVERRIDE_PLUGIN =
-            "id(\"io.github.amos-pitmutationmate.pitmutationmate.override\") version \"1.1\""
+            "id(\"io.github.amos-pitmutationmate.pitmutationmate.override\") version \"1.2\""
 
         private const val GROOVY_PITEST_PLUGIN = "id 'info.solidsoft.pitest' version 'x.y.z'"
         private const val GROOVY_OVERRIDE_PLUGIN =
-            "id \"io.github.amos-pitmutationmate.pitmutationmate.override\" version \"1.1\""
+            "id \"io.github.amos-pitmutationmate.pitmutationmate.override\" version \"1.2\""
 
         const val ERROR_MESSAGE_TITLE = "Plugins for PITMutationPlugin are missing"
         private val ERROR_MESSAGE_PITEST_PLUGIN_MISSING = """<b>The pitest gradle Plugin is missing.</b>


### PR DESCRIPTION
Removes functional test things that were added from the gradle template but were never actually used.
Also coverage-reporter needed the jvm version set to 11 for it to work work with java 11